### PR TITLE
fix: only use processingWg in test

### DIFF
--- a/internal/manager/workload_manager_test.go
+++ b/internal/manager/workload_manager_test.go
@@ -42,7 +42,13 @@ func TestWorkloadManager(t *testing.T) {
 		start := make(chan struct{}) // barrier to synchronize goroutines
 
 		numWorkloads := 10
-		mgr.addDispatcher.processingWg.Add(numWorkloads)
+		var processingWg sync.WaitGroup
+		processingWg.Add(numWorkloads)
+
+		mgr.addDispatcher.postProcessingHook = func(ctx context.Context, obj *model.Workload) error {
+			processingWg.Done()
+			return nil
+		}
 		for i := 0; i < numWorkloads; i++ {
 			wg.Add(1)
 			go func(id int) {
@@ -54,7 +60,7 @@ func TestWorkloadManager(t *testing.T) {
 
 		close(start)
 		wg.Wait()
-		mgr.addDispatcher.processingWg.Wait()
+		processingWg.Wait()
 	})
 }
 


### PR DESCRIPTION
* refactor to use a post processing hook function where e.g. wg.Done can be invoked in sync with increments