### PR TITLE
feat: add LastUpdated field to vulnerability summary

### DIFF
--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -133,7 +133,7 @@ func (s *Server) GetVulnerabilitySummary(ctx context.Context, request *vulnerabi
 		Unassigned:  row.Unassigned,
 		Total:       row.Critical + row.High + row.Medium + row.Low + row.Unassigned,
 		RiskScore:   row.RiskScore,
-		LastUpdated: timestamppb.New(row.SummaryUpdatedAt.Time),
+		LastUpdated: timestamppb.New(row.UpdatedAt.Time),
 		HasSbom:     true,
 	}
 

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -124,7 +124,7 @@ SELECT
     CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
     CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
     CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
-    MAX(v.updated_at)::DATE AS summary_updated_at
+    MAX(v.updated_at)::timestamptz AS updated_at
 FROM filtered_workloads fw
          LEFT JOIN vulnerability_summary v
                    ON fw.image_name = v.image_name AND fw.image_tag = v.image_tag;

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -88,7 +88,7 @@ SELECT
     CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
     CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
     CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
-    MAX(v.updated_at)::DATE AS summary_updated_at
+    MAX(v.updated_at)::timestamptz AS updated_at
 FROM filtered_workloads fw
          LEFT JOIN vulnerability_summary v
                    ON fw.image_name = v.image_name AND fw.image_tag = v.image_tag
@@ -110,7 +110,7 @@ type GetVulnerabilitySummaryRow struct {
 	Low              int32
 	Unassigned       int32
 	RiskScore        int32
-	SummaryUpdatedAt pgtype.Date
+	UpdatedAt        pgtype.Timestamptz
 }
 
 func (q *Queries) GetVulnerabilitySummary(ctx context.Context, arg GetVulnerabilitySummaryParams) (*GetVulnerabilitySummaryRow, error) {
@@ -130,7 +130,7 @@ func (q *Queries) GetVulnerabilitySummary(ctx context.Context, arg GetVulnerabil
 		&i.Low,
 		&i.Unassigned,
 		&i.RiskScore,
-		&i.SummaryUpdatedAt,
+		&i.UpdatedAt,
 	)
 	return &i, err
 }

--- a/pkg/cli/commands/get.go
+++ b/pkg/cli/commands/get.go
@@ -53,7 +53,7 @@ func getSummary(ctx context.Context, cmd *cli.Command, c vulnerabilities.Client,
 	headerFmt := color.New(color.FgGreen, color.Underline).SprintfFunc()
 	columnFmt := color.New(color.FgYellow).SprintfFunc()
 
-	tbl := table.New("Workload Count", "SBOM Count", "Critical", "High", "Medium", "Low", "Unassigned", "Risk Score", "Coverage", "Missing SBOMs")
+	tbl := table.New("Workload Count", "SBOM Count", "Critical", "High", "Medium", "Low", "Unassigned", "Risk Score", "Coverage", "Missing SBOMs", "Last Updated")
 	tbl.WithHeaderFormatter(headerFmt).WithFirstColumnFormatter(columnFmt)
 
 	tbl.AddRow(
@@ -67,6 +67,7 @@ func getSummary(ctx context.Context, cmd *cli.Command, c vulnerabilities.Client,
 		resp.GetVulnerabilitySummary().GetRiskScore(),
 		resp.GetCoverage(),
 		resp.GetWorkloadCount()-resp.GetSbomCount(),
+		resp.GetVulnerabilitySummary().LastUpdated.AsTime().Format(time.RFC3339),
 	)
 
 	tbl.Print()


### PR DESCRIPTION
* update SQL queries

Dette returnerer den nyeste updated_at-verdien blant alle treff i databasen – uansett hvor gammel den er.
Så selv om siste oppdatering var for ett år siden, vil den verdien likevel bli returnert.