### PR TITLE
bump: siste cloudsql proxy

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -3,7 +3,7 @@ image:
   repository: europe-north1-docker.pkg.dev/nais-io/nais/images
   name: v13s
   tag: tull
-  cloudsql_proxy: gcr.io/cloudsql-docker/gce-proxy:1.33.16
+  cloudsql_proxy: gcr.io/cloudsql-docker/gce-proxy:1.37.8
 serviceAccountEmail:
 serviceAccountName: v13s-sa
 updateInterval: 5m


### PR DESCRIPTION
Ingen nevneverdige endringer, bortsett fra at man nå ved oppstart vil få en melding om å migrere til v2.

https://github.com/GoogleCloudPlatform/cloud-sql-proxy/blob/main/migration-guide.md