### PR TITLE
test: add tests for alias canonicalization and suppression behavior

### DIFF
--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -1727,6 +1727,8 @@ func TestServer_ListCveSummaries(t *testing.T) {
 	})
 }
 
+func ptrTime(t time.Time) *time.Time { return &t }
+
 func setupTest(t *testing.T, cfg testSetupConfig, testContainers bool) (context.Context, *sql.Queries, *pgxpool.Pool, vulnerabilities.Client, func()) {
 	ctx := context.Background()
 	pool := test.GetPool(ctx, t, testContainers)

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -1723,7 +1723,7 @@ func TestServer_ListCveSummaries(t *testing.T) {
 	})
 }
 
-func TestServer_SuppressVulnerability_AliasCanonical(t *testing.T) {
+func TestServer_SuppressAliasCanonicalizesAndIsRespectedEverywhere(t *testing.T) {
 	cfg := testSetupConfig{
 		clusters:              []string{"cluster-1"},
 		namespaces:            []string{"namespace-1"},

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -1270,8 +1270,7 @@ func TestServer_ListMeanTimeToFixTrend(t *testing.T) {
 				snap := v.SnapshotDate.Truncate(24 * time.Hour)
 				var fixed *time.Time
 				if v.FixedAt != nil {
-					tmp := v.FixedAt.Truncate(24 * time.Hour)
-					fixed = &tmp
+					fixed = new(v.FixedAt.Truncate(24 * time.Hour))
 				}
 
 				fixedFlag := fixed != nil
@@ -1632,13 +1631,10 @@ func TestServer_ListCveSummaries(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		cvssScoreZero := 0.0
-		cvssScoreLow := 2.5
-		cvssScoreHigh := 9.8
 		db.BatchUpsertCve(ctx, []sql.BatchUpsertCveParams{
-			{CveID: "CVE-LOW", CveTitle: "Low", CveDesc: "desc", CveLink: "link", CvssScore: &cvssScoreLow, Severity: 2, Refs: map[string]string{}},
-			{CveID: "CVE-HIGH", CveTitle: "High", CveDesc: "desc", CveLink: "link", CvssScore: &cvssScoreHigh, Severity: 1, Refs: map[string]string{}},
-			{CveID: "CVE-ZERO", CveTitle: "Zero", CveDesc: "desc", CveLink: "link", CvssScore: &cvssScoreZero, Severity: 0, Refs: map[string]string{}},
+			{CveID: "CVE-LOW", CveTitle: "Low", CveDesc: "desc", CveLink: "link", CvssScore: new(2.5), Severity: 2, Refs: map[string]string{}},
+			{CveID: "CVE-HIGH", CveTitle: "High", CveDesc: "desc", CveLink: "link", CvssScore: new(9.8), Severity: 1, Refs: map[string]string{}},
+			{CveID: "CVE-ZERO", CveTitle: "Zero", CveDesc: "desc", CveLink: "link", CvssScore: new(0.0), Severity: 0, Refs: map[string]string{}},
 		}).Exec(func(i int, err error) { assert.NoError(t, err) })
 
 		db.BatchUpsertVulnerabilities(ctx, []sql.BatchUpsertVulnerabilitiesParams{
@@ -1727,7 +1723,205 @@ func TestServer_ListCveSummaries(t *testing.T) {
 	})
 }
 
-func ptrTime(t time.Time) *time.Time { return &t }
+func TestServer_SuppressVulnerability_AliasCanonical(t *testing.T) {
+	cfg := testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1"},
+		workloadsPerNamespace: 1,
+		vulnsPerWorkload:      0,
+	}
+
+	ctx, db, _, client, cleanup := setupTest(t, cfg, true)
+	defer cleanup()
+
+	const (
+		imageName   = "image-cluster-1-namespace-1-workload-1"
+		imageTag    = "v1.0"
+		pkg         = "alias-package"
+		canonicalID = "CVE-2025-CANONICAL"
+		aliasID     = "GHSA-2025-ALIAS"
+	)
+
+	// Seed canonical CVE and alias CVE rows.
+	// Both must exist in the cve table because cve_alias.alias has a FK -> cve(cve_id).
+	db.BatchUpsertCve(ctx, []sql.BatchUpsertCveParams{
+		{
+			CveID:    canonicalID,
+			CveTitle: "Canonical CVE title",
+			CveDesc:  "Canonical CVE description",
+			CveLink:  "http://example.com/" + canonicalID,
+			Severity: 1, // HIGH
+			Refs:     typeext.MapStringString{},
+		},
+		{
+			CveID:    aliasID,
+			CveTitle: "Alias CVE title",
+			CveDesc:  "Alias CVE description",
+			CveLink:  "http://example.com/" + aliasID,
+			Severity: 1,
+			Refs:     typeext.MapStringString{},
+		},
+	}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	// Seed alias: aliasID -> canonicalID.
+	db.BatchUpsertCveAlias(ctx, []sql.BatchUpsertCveAliasParams{{
+		Alias:          aliasID,
+		CanonicalCveID: canonicalID,
+	}}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	// Seed a vulnerability row using the alias CVE ID
+	db.BatchUpsertVulnerabilities(ctx, []sql.BatchUpsertVulnerabilitiesParams{{
+		ImageName:     imageName,
+		ImageTag:      imageTag,
+		Package:       pkg,
+		CveID:         aliasID,
+		Source:        "test",
+		LatestVersion: "1.0.0",
+		LastSeverity:  1,
+		SeveritySince: pgtype.Timestamptz{Time: time.Now(), Valid: true},
+	}}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	// Obtain the vulnerability UUID via GetVulnerability (lookup by alias cve_id).
+	getResp, err := client.GetVulnerability(ctx, imageName, imageTag, pkg, aliasID)
+	require.NoError(t, err)
+	require.NotNil(t, getResp.GetVulnerability())
+	vulnID := getResp.GetVulnerability().GetId()
+	require.NotEmpty(t, vulnID)
+
+	t.Run("before suppression: GetVulnerability not suppressed", func(t *testing.T) {
+		resp, err := client.GetVulnerability(ctx, imageName, imageTag, pkg, aliasID)
+		require.NoError(t, err)
+		assert.False(t, resp.GetVulnerability().GetSuppression().GetSuppressed())
+	})
+
+	t.Run("before suppression: GetVulnerabilityById not suppressed", func(t *testing.T) {
+		resp, err := client.GetVulnerabilityById(ctx, vulnID)
+		require.NoError(t, err)
+		assert.False(t, resp.GetVulnerability().GetSuppression().GetSuppressed())
+	})
+
+	t.Run("before suppression: ListSuppressedVulnerabilities returns empty", func(t *testing.T) {
+		resp, err := client.ListSuppressedVulnerabilities(ctx,
+			vulnerabilities.ImageFilter(imageName, imageTag),
+		)
+		require.NoError(t, err)
+		// filter to just our package/CVE in case other tests left rows
+		found := false
+		for _, n := range resp.Nodes {
+			if n.GetPackage() == pkg {
+				found = true
+			}
+		}
+		assert.False(t, found, "expected no suppression rows for alias-package before suppression")
+	})
+
+	// Suppress via the vulnerability UUID (internally resolves alias -> canonical).
+	err = client.SuppressVulnerability(
+		ctx,
+		vulnID,
+		"not affected by alias vuln",
+		"alias-tester",
+		vulnerabilities.SuppressState_NOT_AFFECTED,
+		true,
+	)
+	require.NoError(t, err)
+
+	// After suppression: all read paths must reflect suppressed = true.
+	t.Run("after suppression: GetVulnerability is suppressed", func(t *testing.T) {
+		resp, err := client.GetVulnerability(ctx, imageName, imageTag, pkg, aliasID)
+		require.NoError(t, err)
+		sup := resp.GetVulnerability().GetSuppression()
+		require.NotNil(t, sup, "suppression should be set")
+		assert.True(t, sup.GetSuppressed())
+		assert.Equal(t, vulnerabilities.SuppressState_NOT_AFFECTED, sup.GetSuppressedReason())
+		assert.Equal(t, "not affected by alias vuln", sup.GetSuppressedDetails())
+		assert.Equal(t, "alias-tester", sup.GetSuppressedBy())
+	})
+
+	t.Run("after suppression: GetVulnerabilityById is suppressed", func(t *testing.T) {
+		resp, err := client.GetVulnerabilityById(ctx, vulnID)
+		require.NoError(t, err)
+		sup := resp.GetVulnerability().GetSuppression()
+		require.NotNil(t, sup, "suppression should be set")
+		assert.True(t, sup.GetSuppressed())
+		assert.Equal(t, vulnerabilities.SuppressState_NOT_AFFECTED, sup.GetSuppressedReason())
+		assert.Equal(t, "alias-tester", sup.GetSuppressedBy())
+	})
+
+	t.Run("after suppression: ListSuppressedVulnerabilities includes alias-backed vuln", func(t *testing.T) {
+		resp, err := client.ListSuppressedVulnerabilities(ctx,
+			vulnerabilities.ImageFilter(imageName, imageTag),
+		)
+		require.NoError(t, err)
+		found := false
+		for _, n := range resp.Nodes {
+			if n.GetPackage() == pkg {
+				found = true
+				assert.True(t, n.GetSuppress())
+				assert.Equal(t, "alias-tester", n.GetSuppressedBy())
+			}
+		}
+		assert.True(t, found, "expected alias-package to appear in ListSuppressedVulnerabilities")
+	})
+
+	t.Run("after suppression: ListVulnerabilities hides suppressed by default", func(t *testing.T) {
+		resp, err := client.ListVulnerabilities(ctx,
+			vulnerabilities.ImageFilter(imageName, imageTag),
+			vulnerabilities.Limit(100),
+		)
+		require.NoError(t, err)
+		for _, n := range resp.Nodes {
+			if n.Vulnerability.Package == pkg {
+				t.Errorf("suppressed vulnerability (package=%s) should not appear without IncludeSuppressed", pkg)
+			}
+		}
+	})
+
+	t.Run("after suppression: ListVulnerabilities with IncludeSuppressed shows suppressed flag", func(t *testing.T) {
+		resp, err := client.ListVulnerabilities(ctx,
+			vulnerabilities.ImageFilter(imageName, imageTag),
+			vulnerabilities.IncludeSuppressed(),
+			vulnerabilities.Limit(100),
+		)
+		require.NoError(t, err)
+		found := false
+		for _, n := range resp.Nodes {
+			if n.Vulnerability.Package == pkg {
+				found = true
+				sup := n.Vulnerability.GetSuppression()
+				require.NotNil(t, sup)
+				assert.True(t, sup.GetSuppressed())
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("suppression row is keyed by canonical CVE ID, not alias", func(t *testing.T) {
+		rows, err := db.ListSuppressedVulnerabilitiesForImage(ctx, imageName)
+		require.NoError(t, err)
+		found := false
+		for _, r := range rows {
+			if r.Package == pkg {
+				found = true
+				assert.Equal(t, canonicalID, r.CveID,
+					"suppressed_vulnerabilities.cve_id should be the canonical ID, not the alias")
+				assert.NotEqual(t, aliasID, r.CveID,
+					"suppressed_vulnerabilities.cve_id must not be the alias")
+			}
+		}
+		assert.True(t, found, "expected a suppression row for alias-package")
+	})
+
+	t.Run("after unsuppression: GetVulnerability is no longer suppressed", func(t *testing.T) {
+		err := client.SuppressVulnerability(ctx, vulnID, "", "alias-tester",
+			vulnerabilities.SuppressState_NOT_SET, false)
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerability(ctx, imageName, imageTag, pkg, aliasID)
+		require.NoError(t, err)
+		assert.False(t, resp.GetVulnerability().GetSuppression().GetSuppressed())
+	})
+}
 
 func setupTest(t *testing.T, cfg testSetupConfig, testContainers bool) (context.Context, *sql.Queries, *pgxpool.Pool, vulnerabilities.Client, func()) {
 	ctx := context.Background()

--- a/internal/attestation/attestation.go
+++ b/internal/attestation/attestation.go
@@ -75,8 +75,7 @@ func NewVerifier(_ context.Context, log *logrus.Entry, organizations ...string) 
 	v.verifyFunc = func(ctx context.Context, ref name.Reference, co *cosign.CheckOpts) ([]oci.Signature, error) {
 		sigs, _, err := cosign.VerifyImageAttestations(ctx, ref, co)
 
-		var tErr *transport.Error
-		if errors.As(err, &tErr) {
+		if tErr, ok := errors.AsType[*transport.Error](err); ok {
 			if tErr.StatusCode >= 400 && tErr.StatusCode < 500 {
 				return sigs, model.ToUnrecoverableError(
 					fmt.Errorf("status: %d, error: %w", tErr.StatusCode, tErr),
@@ -152,8 +151,7 @@ func (v *verifier) verifyBundleFormat(ctx context.Context, ref name.Reference) (
 	}
 
 	shouldFallback := len(sigs) == 0
-	var noMatch *cosign.ErrNoMatchingAttestations
-	if errors.As(err, &noMatch) {
+	if _, ok := errors.AsType[*cosign.ErrNoMatchingAttestations](err); ok {
 		shouldFallback = true
 	}
 
@@ -176,8 +174,7 @@ func (v *verifier) verifyBundleFormat(ctx context.Context, ref name.Reference) (
 
 	// Prefer legacy error if we tried it; otherwise return v3 error
 	if legacyErr != nil {
-		var noMatch *cosign.ErrNoMatchingAttestations
-		if errors.As(legacyErr, &noMatch) {
+		if _, ok := errors.AsType[*cosign.ErrNoMatchingAttestations](legacyErr); ok {
 			v.log.WithError(legacyErr).WithField("ref", ref.String()).Info("legacy attestation reported no matching attestations")
 			return nil, legacyErr
 		}
@@ -197,8 +194,7 @@ func (v *verifier) GetAttestation(ctx context.Context, image string) (*Attestati
 
 	verified, err := v.verifyBundleFormat(ctx, ref)
 	if err != nil {
-		var noMatch *cosign.ErrNoMatchingAttestations
-		if errors.As(err, &noMatch) {
+		if _, ok := errors.AsType[*cosign.ErrNoMatchingAttestations](err); ok {
 			return nil, err
 		}
 		return nil, err

--- a/internal/database/queries/cve_summary.sql
+++ b/internal/database/queries/cve_summary.sql
@@ -5,12 +5,13 @@ WITH cve_data AS (
         COUNT(DISTINCT w.id)::INT AS affected_workloads
     FROM
         vulnerabilities v
-        JOIN cve c ON v.cve_id = c.cve_id
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
         JOIN workloads w ON w.image_name = v.image_name
             AND w.image_tag = v.image_tag
         LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
             AND v.package = sv.package
-            AND v.cve_id = sv.cve_id
+            AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
     WHERE (sqlc.narg('cluster')::TEXT IS NULL
         OR w.cluster = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -627,7 +627,6 @@ ORDER BY
 LIMIT sqlc.arg('limit')
     OFFSET sqlc.arg('offset');
 
--- TODO: use ctes like ListVulnerabilitiesForImage to handle aliases for CVE IDs
 -- name: ListVulnerabilities :many
 WITH resolved_vulnerabilities AS (
     SELECT

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -280,6 +280,12 @@ ORDER BY
     w.name;
 
 -- name: SuppressVulnerability :exec
+WITH canonical AS (
+    SELECT COALESCE(
+        (SELECT canonical_cve_id FROM cve_alias WHERE alias = @cve_id),
+        @cve_id
+    ) AS cve_id
+)
 INSERT INTO suppressed_vulnerabilities(
     image_name,
     package,
@@ -288,14 +294,15 @@ INSERT INTO suppressed_vulnerabilities(
     suppressed_by,
     reason,
     reason_text)
-VALUES (
+SELECT
     @image_name,
     @package,
-    @cve_id,
+    canonical.cve_id,
     @suppressed,
     @suppressed_by,
     @reason,
-    @reason_text)
+    @reason_text
+FROM canonical
 ON CONFLICT ON CONSTRAINT image_name_package_cve_id
     DO UPDATE SET
         suppressed = EXCLUDED.suppressed,
@@ -428,37 +435,51 @@ AND (
     END);
 
 -- name: CountVulnerabilities :one
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.image_name,
+        v.image_tag,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        w.cluster,
+        w.namespace,
+        w.workload_type,
+        w.name AS workload_name
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
     COUNT(*) AS total
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE (
     CASE WHEN sqlc.narg('cluster')::TEXT IS NOT NULL THEN
-        w.cluster = sqlc.narg('cluster')::TEXT
+        rv.cluster = sqlc.narg('cluster')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('namespace')::TEXT IS NOT NULL THEN
-        w.namespace = sqlc.narg('namespace')::TEXT
+        rv.namespace = sqlc.narg('namespace')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
-        w.workload_type = sqlc.narg('workload_type')::TEXT
+        rv.workload_type = sqlc.narg('workload_type')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('workload_name')::TEXT IS NOT NULL THEN
-        w.name = sqlc.narg('workload_name')::TEXT
+        rv.workload_name = sqlc.narg('workload_name')::TEXT
     ELSE
         TRUE
     END)
@@ -604,73 +625,99 @@ LIMIT sqlc.arg('limit')
 
 -- TODO: use ctes like ListVulnerabilitiesForImage to handle aliases for CVE IDs
 -- name: ListVulnerabilities :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.severity_since,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    v.image_name,
-    v.image_tag,
-    v.latest_version,
-    v.severity_since,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.severity_since,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score
+    rv.cvss_score
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE (
     CASE WHEN sqlc.narg('cluster')::TEXT IS NOT NULL THEN
-        w.cluster = sqlc.narg('cluster')::TEXT
+        rv.cluster = sqlc.narg('cluster')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('namespace')::TEXT IS NOT NULL THEN
-        w.namespace = sqlc.narg('namespace')::TEXT
+        rv.namespace = sqlc.narg('namespace')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
-        w.workload_type = sqlc.narg('workload_type')::TEXT
+        rv.workload_type = sqlc.narg('workload_type')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('workload_name')::TEXT IS NOT NULL THEN
-        w.name = sqlc.narg('workload_name')::TEXT
+        rv.workload_name = sqlc.narg('workload_name')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('image_name')::TEXT IS NOT NULL THEN
-        v.image_name = sqlc.narg('image_name')::TEXT
+        rv.image_name = sqlc.narg('image_name')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('image_tag')::TEXT IS NOT NULL THEN
-        v.image_tag = sqlc.narg('image_tag')::TEXT
+        rv.image_tag = sqlc.narg('image_tag')::TEXT
     ELSE
         TRUE
     END)
@@ -678,42 +725,42 @@ AND (sqlc.narg('include_suppressed')::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
     CASE WHEN sqlc.narg('order_by') = 'severity_asc' THEN
-        c.severity
+        rv.severity
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'severity_desc' THEN
-        c.severity
+        rv.severity
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'created_at_asc' THEN
-        v.created_at
+        rv.created_at
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'created_at_desc' THEN
-        v.created_at
+        rv.created_at
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'updated_at_asc' THEN
-        v.updated_at
+        rv.updated_at
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'updated_at_desc' THEN
-        v.updated_at
+        rv.updated_at
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT sqlc.arg('limit')
 OFFSET sqlc.arg('offset');
 
@@ -728,187 +775,241 @@ ORDER BY
     updated_at DESC;
 
 -- name: ListSeverityVulnerabilitiesSince :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.severity_since,
+        v.last_severity,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    v.image_name,
-    v.image_tag,
-    v.latest_version,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    v.severity_since,
-    v.last_severity,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.severity_since,
+    rv.last_severity,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score
+    rv.cvss_score
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE
-    v.severity_since IS NOT NULL
+    rv.severity_since IS NOT NULL
     AND (
         CASE WHEN sqlc.narg('cluster')::TEXT IS NOT NULL THEN
-            w.cluster = sqlc.narg('cluster')::TEXT
+            rv.cluster = sqlc.narg('cluster')::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN sqlc.narg('namespace')::TEXT IS NOT NULL THEN
-            w.namespace = sqlc.narg('namespace')::TEXT
+            rv.namespace = sqlc.narg('namespace')::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
-            w.workload_type = sqlc.narg('workload_type')::TEXT
+            rv.workload_type = sqlc.narg('workload_type')::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN sqlc.narg('workload_name')::TEXT IS NOT NULL THEN
-            w.name = sqlc.narg('workload_name')::TEXT
+            rv.workload_name = sqlc.narg('workload_name')::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN sqlc.narg('image_name')::TEXT IS NOT NULL THEN
-            v.image_name = sqlc.narg('image_name')::TEXT
+            rv.image_name = sqlc.narg('image_name')::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN sqlc.narg('image_tag')::TEXT IS NOT NULL THEN
-            v.image_tag = sqlc.narg('image_tag')::TEXT
+            rv.image_tag = sqlc.narg('image_tag')::TEXT
         ELSE
             TRUE
         END)
     AND (sqlc.narg('include_suppressed')::BOOLEAN IS TRUE
         OR COALESCE(sv.suppressed, FALSE) = FALSE)
     AND (sqlc.narg('since')::TIMESTAMPTZ IS NULL
-        OR v.severity_since > sqlc.narg('since')::TIMESTAMPTZ)
+        OR rv.severity_since > sqlc.narg('since')::TIMESTAMPTZ)
 ORDER BY
     CASE WHEN sqlc.narg('order_by') = 'severity_since_desc' THEN
-        v.severity_since
+        rv.severity_since
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'severity_since_asc' THEN
-        v.severity_since
+        rv.severity_since
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT sqlc.arg('limit')
 OFFSET sqlc.arg('offset');
 
 -- name: ListWorkloadsForVulnerabilities :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.severity_since,
+        v.last_severity,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON w.image_name = v.image_name
+            AND w.image_tag = v.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    w.image_name,
-    w.image_tag,
-    v.latest_version,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    v.severity_since,
-    v.last_severity,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.severity_since,
+    rv.last_severity,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score,
-    COUNT(v.id) OVER () AS total_count
+    rv.cvss_score,
+    COUNT(rv.id) OVER () AS total_count
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON w.image_name = v.image_name
-        AND w.image_tag = v.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE (sqlc.narg('cve_ids')::TEXT[] IS NULL
-    OR v.cve_id = ANY (sqlc.narg('cve_ids')::TEXT[]))
+    OR rv.cve_id = ANY (sqlc.narg('cve_ids')::TEXT[]))
 AND (sqlc.narg('cvss_score')::FLOAT8 IS NULL
-    OR (v.cvss_score IS NOT NULL
-        AND v.cvss_score >= sqlc.narg('cvss_score')::FLOAT8))
+    OR (rv.cvss_score IS NOT NULL
+        AND rv.cvss_score >= sqlc.narg('cvss_score')::FLOAT8))
 AND (
     CASE WHEN sqlc.narg('cluster')::TEXT IS NOT NULL THEN
-        w.cluster = sqlc.narg('cluster')::TEXT
+        rv.cluster = sqlc.narg('cluster')::TEXT
     ELSE
         TRUE
     END)
 AND (cardinality(sqlc.arg('exclude_clusters')::TEXT[]) = 0
-    OR w.cluster <> ALL (sqlc.arg('exclude_clusters')::TEXT[]))
+    OR rv.cluster <> ALL (sqlc.arg('exclude_clusters')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('namespace')::TEXT IS NOT NULL THEN
-        w.namespace = sqlc.narg('namespace')::TEXT
+        rv.namespace = sqlc.narg('namespace')::TEXT
     ELSE
         TRUE
     END)
 AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
-    OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
+    OR rv.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
 AND (sqlc.narg('workload_types')::TEXT[] IS NULL
-    OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
+    OR rv.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_name')::TEXT IS NOT NULL THEN
-        w.name = sqlc.narg('workload_name')::TEXT
+        rv.workload_name = sqlc.narg('workload_name')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('image_name')::TEXT IS NOT NULL THEN
-        v.image_name = sqlc.narg('image_name')::TEXT
+        rv.image_name = sqlc.narg('image_name')::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN sqlc.narg('image_tag')::TEXT IS NOT NULL THEN
-        v.image_tag = sqlc.narg('image_tag')::TEXT
+        rv.image_tag = sqlc.narg('image_tag')::TEXT
     ELSE
         TRUE
     END)
@@ -916,44 +1017,44 @@ AND (sqlc.narg('include_suppressed')::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
     CASE WHEN sqlc.narg('order_by') = 'cvss_score_desc' THEN
-        CASE WHEN v.cvss_score = 0
-            OR v.cvss_score IS NULL THEN
+        CASE WHEN rv.cvss_score = 0
+            OR rv.cvss_score IS NULL THEN
             1
         ELSE
             0
         END
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'cvss_score_desc' THEN
-        v.cvss_score
+        rv.cvss_score
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'cvss_score_asc' THEN
-        v.cvss_score
+        rv.cvss_score
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'cve_id_desc' THEN
-        v.cve_id
+        rv.cve_id
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'cve_id_asc' THEN
-        v.cve_id
+        rv.cve_id
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN sqlc.narg('order_by') = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT sqlc.arg('limit')
 OFFSET sqlc.arg('offset');
 

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -219,10 +219,11 @@ SELECT
     sv.updated_at AS suppressed_at
 FROM
     vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
     LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
         AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+        AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
 WHERE
     v.image_name = @image_name
     AND v.image_tag = @image_tag
@@ -252,10 +253,11 @@ SELECT
     sv.updated_at AS suppressed_at
 FROM
     vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
     LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
         AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+        AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
 WHERE
     v.id = @id;
 
@@ -329,8 +331,9 @@ FROM
     suppressed_vulnerabilities sv
     JOIN vulnerabilities v ON sv.image_name = v.image_name
         AND sv.package = v.package
-        AND sv.cve_id = v.cve_id
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        AND sv.cve_id = c.cve_id
     JOIN workloads w ON v.image_name = w.image_name
         AND v.image_tag = w.image_tag
 WHERE (
@@ -393,8 +396,9 @@ FROM
     suppressed_vulnerabilities sv
     JOIN vulnerabilities v ON sv.image_name = v.image_name
         AND sv.package = v.package
-        AND sv.cve_id = v.cve_id
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        AND sv.cve_id = c.cve_id
     JOIN workloads w ON v.image_name = w.image_name
         AND v.image_tag = w.image_tag
 WHERE (

--- a/internal/database/sql/cve_summary.sql.go
+++ b/internal/database/sql/cve_summary.sql.go
@@ -16,12 +16,13 @@ WITH cve_data AS (
         COUNT(DISTINCT w.id)::INT AS affected_workloads
     FROM
         vulnerabilities v
-        JOIN cve c ON v.cve_id = c.cve_id
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
         JOIN workloads w ON w.image_name = v.image_name
             AND w.image_tag = v.image_tag
         LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
             AND v.package = sv.package
-            AND v.cve_id = sv.cve_id
+            AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
     WHERE ($4::TEXT IS NULL
         OR w.cluster = $4::TEXT)
     AND ($5::TEXT IS NULL

--- a/internal/database/sql/querier.go
+++ b/internal/database/sql/querier.go
@@ -47,7 +47,6 @@ type Querier interface {
 	ListUnusedImages(ctx context.Context, name *string) ([]*ListUnusedImagesRow, error)
 	ListUnusedSourceRefs(ctx context.Context, name *string) ([]*SourceRef, error)
 	ListUpdatedWorkloadsWithSummaries(ctx context.Context) ([]*ListUpdatedWorkloadsWithSummariesRow, error)
-	// TODO: use ctes like ListVulnerabilitiesForImage to handle aliases for CVE IDs
 	ListVulnerabilities(ctx context.Context, arg ListVulnerabilitiesParams) ([]*ListVulnerabilitiesRow, error)
 	ListVulnerabilitiesForImage(ctx context.Context, arg ListVulnerabilitiesForImageParams) ([]*ListVulnerabilitiesForImageRow, error)
 	ListVulnerabilitySummaries(ctx context.Context, arg ListVulnerabilitySummariesParams) ([]*ListVulnerabilitySummariesRow, error)

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -990,7 +990,6 @@ type ListVulnerabilitiesRow struct {
 	CvssScore     *float64
 }
 
-// TODO: use ctes like ListVulnerabilitiesForImage to handle aliases for CVE IDs
 func (q *Queries) ListVulnerabilities(ctx context.Context, arg ListVulnerabilitiesParams) ([]*ListVulnerabilitiesRow, error) {
 	rows, err := q.db.Query(ctx, listVulnerabilities,
 		arg.Cluster,

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -17,8 +17,9 @@ FROM
     suppressed_vulnerabilities sv
     JOIN vulnerabilities v ON sv.image_name = v.image_name
         AND sv.package = v.package
-        AND sv.cve_id = v.cve_id
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        AND sv.cve_id = c.cve_id
     JOIN workloads w ON v.image_name = w.image_name
         AND v.image_tag = w.image_tag
 WHERE (
@@ -245,10 +246,11 @@ SELECT
     sv.updated_at AS suppressed_at
 FROM
     vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
     LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
         AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+        AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
 WHERE
     v.image_name = $1
     AND v.image_tag = $2
@@ -344,10 +346,11 @@ SELECT
     sv.updated_at AS suppressed_at
 FROM
     vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
     LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
         AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+        AND COALESCE(ca.canonical_cve_id, v.cve_id) = sv.cve_id
 WHERE
     v.id = $1
 `
@@ -622,8 +625,9 @@ FROM
     suppressed_vulnerabilities sv
     JOIN vulnerabilities v ON sv.image_name = v.image_name
         AND sv.package = v.package
-        AND sv.cve_id = v.cve_id
-    JOIN cve c ON v.cve_id = c.cve_id
+    LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+    JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        AND sv.cve_id = c.cve_id
     JOIN workloads w ON v.image_name = w.image_name
         AND v.image_tag = w.image_tag
 WHERE (

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -84,37 +84,51 @@ func (q *Queries) CountSuppressedVulnerabilities(ctx context.Context, arg CountS
 }
 
 const countVulnerabilities = `-- name: CountVulnerabilities :one
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.image_name,
+        v.image_tag,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        w.cluster,
+        w.namespace,
+        w.workload_type,
+        w.name AS workload_name
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
     COUNT(*) AS total
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE (
     CASE WHEN $1::TEXT IS NOT NULL THEN
-        w.cluster = $1::TEXT
+        rv.cluster = $1::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $2::TEXT IS NOT NULL THEN
-        w.namespace = $2::TEXT
+        rv.namespace = $2::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.workload_type = $3::TEXT
+        rv.workload_type = $3::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
-        w.name = $4::TEXT
+        rv.workload_name = $4::TEXT
     ELSE
         TRUE
     END)
@@ -405,109 +419,136 @@ func (q *Queries) GetVulnerabilityById(ctx context.Context, id pgtype.UUID) (*Ge
 }
 
 const listSeverityVulnerabilitiesSince = `-- name: ListSeverityVulnerabilitiesSince :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.severity_since,
+        v.last_severity,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    v.image_name,
-    v.image_tag,
-    v.latest_version,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    v.severity_since,
-    v.last_severity,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.severity_since,
+    rv.last_severity,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score
+    rv.cvss_score
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE
-    v.severity_since IS NOT NULL
+    rv.severity_since IS NOT NULL
     AND (
         CASE WHEN $1::TEXT IS NOT NULL THEN
-            w.cluster = $1::TEXT
+            rv.cluster = $1::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $2::TEXT IS NOT NULL THEN
-            w.namespace = $2::TEXT
+            rv.namespace = $2::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $3::TEXT IS NOT NULL THEN
-            w.workload_type = $3::TEXT
+            rv.workload_type = $3::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $4::TEXT IS NOT NULL THEN
-            w.name = $4::TEXT
+            rv.workload_name = $4::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $5::TEXT IS NOT NULL THEN
-            v.image_name = $5::TEXT
+            rv.image_name = $5::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $6::TEXT IS NOT NULL THEN
-            v.image_tag = $6::TEXT
+            rv.image_tag = $6::TEXT
         ELSE
             TRUE
         END)
     AND ($7::BOOLEAN IS TRUE
         OR COALESCE(sv.suppressed, FALSE) = FALSE)
     AND ($8::TIMESTAMPTZ IS NULL
-        OR v.severity_since > $8::TIMESTAMPTZ)
+        OR rv.severity_since > $8::TIMESTAMPTZ)
 ORDER BY
     CASE WHEN $9 = 'severity_since_desc' THEN
-        v.severity_since
+        rv.severity_since
     END DESC,
     CASE WHEN $9 = 'severity_since_asc' THEN
-        v.severity_since
+        rv.severity_since
     END ASC,
     CASE WHEN $9 = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN $9 = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN $9 = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN $9 = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN $9 = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN $9 = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT $11
 OFFSET $10
 `
@@ -835,73 +876,99 @@ func (q *Queries) ListSuppressedVulnerabilitiesForImage(ctx context.Context, ima
 }
 
 const listVulnerabilities = `-- name: ListVulnerabilities :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.severity_since,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON v.image_name = w.image_name
+            AND v.image_tag = w.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    v.image_name,
-    v.image_tag,
-    v.latest_version,
-    v.severity_since,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.severity_since,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score
+    rv.cvss_score
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON v.image_name = w.image_name
-        AND v.image_tag = w.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE (
     CASE WHEN $1::TEXT IS NOT NULL THEN
-        w.cluster = $1::TEXT
+        rv.cluster = $1::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $2::TEXT IS NOT NULL THEN
-        w.namespace = $2::TEXT
+        rv.namespace = $2::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.workload_type = $3::TEXT
+        rv.workload_type = $3::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
-        w.name = $4::TEXT
+        rv.workload_name = $4::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $5::TEXT IS NOT NULL THEN
-        v.image_name = $5::TEXT
+        rv.image_name = $5::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $6::TEXT IS NOT NULL THEN
-        v.image_tag = $6::TEXT
+        rv.image_tag = $6::TEXT
     ELSE
         TRUE
     END)
@@ -909,42 +976,42 @@ AND ($7::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
     CASE WHEN $8 = 'severity_asc' THEN
-        c.severity
+        rv.severity
     END ASC,
     CASE WHEN $8 = 'severity_desc' THEN
-        c.severity
+        rv.severity
     END DESC,
     CASE WHEN $8 = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN $8 = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN $8 = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN $8 = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN $8 = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN $8 = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
     CASE WHEN $8 = 'created_at_asc' THEN
-        v.created_at
+        rv.created_at
     END ASC,
     CASE WHEN $8 = 'created_at_desc' THEN
-        v.created_at
+        rv.created_at
     END DESC,
     CASE WHEN $8 = 'updated_at_asc' THEN
-        v.updated_at
+        rv.updated_at
     END ASC,
     CASE WHEN $8 = 'updated_at_desc' THEN
-        v.updated_at
+        rv.updated_at
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT $10
 OFFSET $9
 `
@@ -1276,80 +1343,107 @@ func (q *Queries) ListVulnerabilitiesForImage(ctx context.Context, arg ListVulne
 }
 
 const listWorkloadsForVulnerabilities = `-- name: ListWorkloadsForVulnerabilities :many
+WITH resolved_vulnerabilities AS (
+    SELECT
+        v.id,
+        v.image_name,
+        v.image_tag,
+        v.latest_version,
+        v.package,
+        COALESCE(ca.canonical_cve_id, v.cve_id)::TEXT AS cve_id,
+        v.created_at,
+        v.updated_at,
+        v.severity_since,
+        v.last_severity,
+        v.cvss_score,
+        w.name AS workload_name,
+        w.workload_type,
+        w.namespace,
+        w.cluster,
+        c.cve_title,
+        c.cve_desc,
+        c.cve_link,
+        c.severity,
+        c.created_at AS cve_created_at,
+        c.updated_at AS cve_updated_at
+    FROM
+        vulnerabilities v
+        LEFT JOIN cve_alias ca ON v.cve_id = ca.alias
+        JOIN cve c ON c.cve_id = COALESCE(ca.canonical_cve_id, v.cve_id)
+        JOIN workloads w ON w.image_name = v.image_name
+            AND w.image_tag = v.image_tag
+)
 SELECT
-    v.id,
-    w.name AS workload_name,
-    w.workload_type,
-    w.namespace,
-    w.cluster,
-    w.image_name,
-    w.image_tag,
-    v.latest_version,
-    v.package,
-    v.cve_id,
-    v.created_at,
-    v.updated_at,
-    v.severity_since,
-    v.last_severity,
-    c.cve_title,
-    c.cve_desc,
-    c.cve_link,
-    c.severity AS severity,
-    c.created_at AS cve_created_at,
-    c.updated_at AS cve_updated_at,
+    rv.id,
+    rv.workload_name,
+    rv.workload_type,
+    rv.namespace,
+    rv.cluster,
+    rv.image_name,
+    rv.image_tag,
+    rv.latest_version,
+    rv.package,
+    rv.cve_id,
+    rv.created_at,
+    rv.updated_at,
+    rv.severity_since,
+    rv.last_severity,
+    rv.cve_title,
+    rv.cve_desc,
+    rv.cve_link,
+    rv.severity,
+    rv.cve_created_at,
+    rv.cve_updated_at,
     COALESCE(sv.suppressed, FALSE) AS suppressed,
     sv.reason,
     sv.reason_text,
     sv.suppressed_by,
     sv.updated_at AS suppressed_at,
-    v.cvss_score,
-    COUNT(v.id) OVER () AS total_count
+    rv.cvss_score,
+    COUNT(rv.id) OVER () AS total_count
 FROM
-    vulnerabilities v
-    JOIN cve c ON v.cve_id = c.cve_id
-    JOIN workloads w ON w.image_name = v.image_name
-        AND w.image_tag = v.image_tag
-    LEFT JOIN suppressed_vulnerabilities sv ON v.image_name = sv.image_name
-        AND v.package = sv.package
-        AND v.cve_id = sv.cve_id
+    resolved_vulnerabilities rv
+    LEFT JOIN suppressed_vulnerabilities sv ON rv.image_name = sv.image_name
+        AND rv.package = sv.package
+        AND rv.cve_id = sv.cve_id
 WHERE ($1::TEXT[] IS NULL
-    OR v.cve_id = ANY ($1::TEXT[]))
+    OR rv.cve_id = ANY ($1::TEXT[]))
 AND ($2::FLOAT8 IS NULL
-    OR (v.cvss_score IS NOT NULL
-        AND v.cvss_score >= $2::FLOAT8))
+    OR (rv.cvss_score IS NOT NULL
+        AND rv.cvss_score >= $2::FLOAT8))
 AND (
     CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.cluster = $3::TEXT
+        rv.cluster = $3::TEXT
     ELSE
         TRUE
     END)
 AND (cardinality($4::TEXT[]) = 0
-    OR w.cluster <> ALL ($4::TEXT[]))
+    OR rv.cluster <> ALL ($4::TEXT[]))
 AND (
     CASE WHEN $5::TEXT IS NOT NULL THEN
-        w.namespace = $5::TEXT
+        rv.namespace = $5::TEXT
     ELSE
         TRUE
     END)
 AND (cardinality($6::TEXT[]) = 0
-    OR w.namespace <> ALL ($6::TEXT[]))
+    OR rv.namespace <> ALL ($6::TEXT[]))
 AND ($7::TEXT[] IS NULL
-    OR w.workload_type = ANY ($7::TEXT[]))
+    OR rv.workload_type = ANY ($7::TEXT[]))
 AND (
     CASE WHEN $8::TEXT IS NOT NULL THEN
-        w.name = $8::TEXT
+        rv.workload_name = $8::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $9::TEXT IS NOT NULL THEN
-        v.image_name = $9::TEXT
+        rv.image_name = $9::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $10::TEXT IS NOT NULL THEN
-        v.image_tag = $10::TEXT
+        rv.image_tag = $10::TEXT
     ELSE
         TRUE
     END)
@@ -1357,44 +1451,44 @@ AND ($11::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
     CASE WHEN $12 = 'cvss_score_desc' THEN
-        CASE WHEN v.cvss_score = 0
-            OR v.cvss_score IS NULL THEN
+        CASE WHEN rv.cvss_score = 0
+            OR rv.cvss_score IS NULL THEN
             1
         ELSE
             0
         END
     END ASC,
     CASE WHEN $12 = 'cvss_score_desc' THEN
-        v.cvss_score
+        rv.cvss_score
     END DESC,
     CASE WHEN $12 = 'cvss_score_asc' THEN
-        v.cvss_score
+        rv.cvss_score
     END ASC,
     CASE WHEN $12 = 'cve_id_desc' THEN
-        v.cve_id
+        rv.cve_id
     END DESC,
     CASE WHEN $12 = 'cve_id_asc' THEN
-        v.cve_id
+        rv.cve_id
     END ASC,
     CASE WHEN $12 = 'workload_asc' THEN
-        w.name
+        rv.workload_name
     END ASC,
     CASE WHEN $12 = 'workload_desc' THEN
-        w.name
+        rv.workload_name
     END DESC,
     CASE WHEN $12 = 'namespace_asc' THEN
-        w.namespace
+        rv.namespace
     END ASC,
     CASE WHEN $12 = 'namespace_desc' THEN
-        w.namespace
+        rv.namespace
     END DESC,
     CASE WHEN $12 = 'cluster_asc' THEN
-        w.cluster
+        rv.cluster
     END ASC,
     CASE WHEN $12 = 'cluster_desc' THEN
-        w.cluster
+        rv.cluster
     END DESC,
-    v.id ASC
+    rv.id ASC
 LIMIT $14
 OFFSET $13
 `
@@ -1660,6 +1754,12 @@ func (q *Queries) RecalculateVulnerabilitySummary(ctx context.Context, arg Recal
 }
 
 const suppressVulnerability = `-- name: SuppressVulnerability :exec
+WITH canonical AS (
+    SELECT COALESCE(
+        (SELECT canonical_cve_id FROM cve_alias WHERE alias = $7),
+        $7
+    ) AS cve_id
+)
 INSERT INTO suppressed_vulnerabilities(
     image_name,
     package,
@@ -1668,14 +1768,15 @@ INSERT INTO suppressed_vulnerabilities(
     suppressed_by,
     reason,
     reason_text)
-VALUES (
+SELECT
     $1,
     $2,
+    canonical.cve_id,
     $3,
     $4,
     $5,
-    $6,
-    $7)
+    $6
+FROM canonical
 ON CONFLICT ON CONSTRAINT image_name_package_cve_id
     DO UPDATE SET
         suppressed = EXCLUDED.suppressed,
@@ -1693,22 +1794,22 @@ ON CONFLICT ON CONSTRAINT image_name_package_cve_id
 type SuppressVulnerabilityParams struct {
 	ImageName    string
 	Package      string
-	CveID        string
 	Suppressed   bool
 	SuppressedBy string
 	Reason       VulnerabilitySuppressReason
 	ReasonText   string
+	CveID        string
 }
 
 func (q *Queries) SuppressVulnerability(ctx context.Context, arg SuppressVulnerabilityParams) error {
 	_, err := q.db.Exec(ctx, suppressVulnerability,
 		arg.ImageName,
 		arg.Package,
-		arg.CveID,
 		arg.Suppressed,
 		arg.SuppressedBy,
 		arg.Reason,
 		arg.ReasonText,
+		arg.CveID,
 	)
 	return err
 }

--- a/scripts/backfill_suppressed_vulnerabilities_canonical_cve_id.sql
+++ b/scripts/backfill_suppressed_vulnerabilities_canonical_cve_id.sql
@@ -1,0 +1,80 @@
+-- backfill_suppressed_vulnerabilities_canonical_cve_id.sql
+--
+-- Run once after deploying the SuppressVulnerability canonicalization change.
+--
+-- Background
+-- ----------
+-- SuppressVulnerability now resolves alias CVE IDs to their canonical counterpart
+-- before writing to suppressed_vulnerabilities.  Rows inserted by the old code path
+-- were keyed by the alias (e.g. "GHSA-…") rather than the canonical ID (e.g. "CVE-…").
+-- All read queries join suppressed_vulnerabilities on the canonical ID, so those
+-- legacy rows are silently invisible without this backfill.
+--
+-- What this script does
+-- ---------------------
+-- 1. For every alias-keyed row that has no canonical counterpart yet:
+--      INSERT a new row under the canonical ID, copying the suppression state.
+-- 2. For every alias-keyed row where a canonical row already exists but the
+--    alias row is newer:
+--      UPDATE the canonical row to reflect the more recent suppression state.
+--
+-- Alias-keyed rows are intentionally left in place — both rows are kept so that
+-- nothing is silently lost if something external still references the alias.
+--
+-- Safety
+-- ------
+-- • Runs inside a single transaction; rolls back automatically on any error.
+-- • Safe to re-run: step 1 uses INSERT … ON CONFLICT DO NOTHING so duplicate
+--   inserts are ignored; step 2 is a no-op when canonical is already up to date.
+
+BEGIN;
+
+-- ── Step 1 ────────────────────────────────────────────────────────────────────
+-- Insert a canonical-keyed copy for every alias-keyed row that has no canonical
+-- counterpart yet.
+INSERT INTO suppressed_vulnerabilities
+    (image_name, package, cve_id, suppressed, suppressed_by, reason, reason_text, updated_at)
+SELECT
+    sv.image_name,
+    sv.package,
+    ca.canonical_cve_id,
+    sv.suppressed,
+    sv.suppressed_by,
+    sv.reason,
+    sv.reason_text,
+    sv.updated_at
+FROM suppressed_vulnerabilities sv
+JOIN cve_alias ca ON sv.cve_id = ca.alias
+ON CONFLICT ON CONSTRAINT image_name_package_cve_id DO NOTHING;
+
+-- ── Step 2 ────────────────────────────────────────────────────────────────────
+-- Where a canonical row already existed before step 1 (ON CONFLICT skipped it),
+-- update it if the alias row carries a more recent suppression state.
+WITH newer_alias AS (
+    SELECT
+        canonical.id AS canonical_id,
+        alias_row.suppressed,
+        alias_row.suppressed_by,
+        alias_row.reason,
+        alias_row.reason_text,
+        alias_row.updated_at
+    FROM suppressed_vulnerabilities alias_row
+    JOIN cve_alias ca ON alias_row.cve_id = ca.alias
+    JOIN suppressed_vulnerabilities canonical
+      ON canonical.image_name = alias_row.image_name
+     AND canonical.package    = alias_row.package
+     AND canonical.cve_id     = ca.canonical_cve_id
+    WHERE alias_row.updated_at > canonical.updated_at
+)
+UPDATE suppressed_vulnerabilities sv
+SET
+    suppressed    = na.suppressed,
+    suppressed_by = na.suppressed_by,
+    reason        = na.reason,
+    reason_text   = na.reason_text,
+    updated_at    = na.updated_at
+FROM newer_alias na
+WHERE sv.id = na.canonical_id;
+
+COMMIT;
+


### PR DESCRIPTION
This improves the handling of CVE aliases throughout the vulnerabilities database and API, ensuring that all queries, suppression logic, and reporting consistently use canonical CVE IDs, even when vulnerabilities are initially referenced by an alias. It also adds a comprehensive test to verify that suppression and listing operations respect alias canonicalization.

**Testing and Verification**

- Added a new test, `TestServer_SuppressAliasCanonicalizesAndIsRespectedEverywhere`, which verifies that vulnerabilities referenced by an alias are exposed, suppressed, and counted correctly using the canonical CVE ID across all relevant API endpoints and database queries.