### PR TITLE
feat: refactor workload handling for river

### DIFF
--- a/charts/templates/prometheus-rule.yaml
+++ b/charts/templates/prometheus-rule.yaml
@@ -54,5 +54,8 @@ spec:
               https://salsa.{{ .Values.fasit.tenant.name }}.cloud.nais.io/projects?searchText={{"{{ $labels.workload_name }}"}}
             consequence: Potential security risk; workload may be exploitable
             action: |
-              Check vulnerabilities in Salsa. Consider patching or redeploying the affected workload.
+              1. Visit Salsa and filter workloads by "nais.io/nais" with CRITICAL vulnerabilities
+              2. Prioritize by criticality of CVEs per workload
+              3. Check for available patches and update images
+              4. Redeploy affected workloads
 {{- end }}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -72,7 +72,7 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		}
 	}()
 
-	if err = metrics.LoadWorkloadMetrics(ctx, pool, log.WithField("subsystem", "metrics-push")); err != nil {
+	if err = metrics.LoadWorkloadMetrics(ctx, pool, log.WithField("subsystem", "metrics-load")); err != nil {
 		log.WithError(err).Error("failed to load metrics from DB")
 	}
 

--- a/internal/manager/add_workload.go
+++ b/internal/manager/add_workload.go
@@ -64,8 +64,8 @@ func (a *AddWorkloadWorker) Work(ctx context.Context, job *river.Job[AddWorkload
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			recordOutput(ctx, JobStatusInitializeWorkloadSkipped)
-			a.log.WithField("workload", workload).Debug("workload already initialized, skipping")
+			recordStatusOutput(ctx, JobStatusInitializeWorkloadSkipped)
+			// a.log.WithField("workload", workload).Debug("workload already initialized, skipping")
 			return nil
 		}
 
@@ -92,6 +92,6 @@ func (a *AddWorkloadWorker) Work(ctx context.Context, job *river.Job[AddWorkload
 	if err != nil {
 		return fmt.Errorf("failed to set workload state %s: %w", sql.WorkloadStateUpdated, err)
 	}
-	recordOutput(ctx, JobStatusUpdated)
+	recordStatusOutput(ctx, JobStatusUpdated)
 	return nil
 }

--- a/internal/manager/decision_tables.go
+++ b/internal/manager/decision_tables.go
@@ -1,0 +1,192 @@
+package manager
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/nais/v13s/internal/attestation"
+	"github.com/nais/v13s/internal/database/sql"
+	"github.com/nais/v13s/internal/model"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+)
+
+// Event is a typed outcome produced by a worker step.
+// Each event maps to exactly one entry in a worker-specific decision table.
+type Event string
+
+// lookupDecision returns the decision for an event or a descriptive error if the
+// table is missing that event. Workers decide whether that error should cancel
+func lookupDecision[T any](table map[Event]T, event Event, tableName string) (T, error) {
+	decision, ok := table[event]
+	if ok {
+		return decision, nil
+	}
+
+	var zero T
+	return zero, fmt.Errorf("no %s decision defined for event %q: this is a bug", tableName, event)
+}
+
+const (
+	// get_attestation events
+	EventAttestationFound       Event = "attestation_found"
+	EventNoMatchingAttestations Event = "no_matching_attestations"
+	EventUnrecoverable          Event = "unrecoverable"
+	EventRecoverableError       Event = "recoverable_error"
+)
+
+// Decision describes the state changes and actions to apply for a given Event.
+// Workers read the Decision returned by their decision table and execute it
+// mechanically — no branching logic required.
+type Decision struct {
+	// WorkloadState is the new workload state to persist, or nil to leave it unchanged.
+	WorkloadState *sql.WorkloadState
+
+	// ImageState is the new image state to persist, or nil to leave it unchanged.
+	ImageState *sql.ImageState
+
+	// JobStatus is recorded as the River job output. Empty means nothing is recorded.
+	JobStatus JobStatus
+
+	// CancelJob stops River from retrying by wrapping the error with river.JobCancel.
+	CancelJob bool
+
+	// EnqueueUpload triggers compression and enqueuing of an UploadAttestationJob.
+	EnqueueUpload bool
+}
+
+// getAttestationDecisions is the single source of truth for get_attestation
+// outcomes. To change behavior, change this table instead of adding branches in
+// GetAttestationWorker.Work.
+var getAttestationDecisions = map[Event]Decision{
+	// Attestation was verified successfully: queue it for upload.
+	EventAttestationFound: {
+		JobStatus:     JobStatusAttestationDownloaded,
+		EnqueueUpload: true,
+	},
+
+	// No matching attestations: mark the workload/image, then let River retry
+	// according to the get_attestation job's MaxAttempts.
+	EventNoMatchingAttestations: {
+		WorkloadState: new(sql.WorkloadStateNoAttestation),
+		ImageState:    new(sql.ImageStateFailed),
+		JobStatus:     JobStatusNoAttestation,
+	},
+
+	// Unrecoverable error (e.g. 4xx from registry, invalid image ref).
+	// Mark the workload/image and tell River to stop retrying.
+	EventUnrecoverable: {
+		WorkloadState: new(sql.WorkloadStateUnrecoverable),
+		ImageState:    new(sql.ImageStateFailed),
+		JobStatus:     JobStatusUnrecoverable,
+		CancelJob:     true,
+	},
+
+	// Transient/network error: no state change, return the error so River retries.
+	EventRecoverableError: {},
+}
+
+// classifyGetAttestationEvent turns verifier.GetAttestation output into a
+// domain event. It is intentionally pure and side-effect free.
+func classifyGetAttestationEvent(att *attestation.Attestation, err error) Event {
+	if err == nil && att != nil {
+		return EventAttestationFound
+	}
+	if _, ok := errors.AsType[*cosign.ErrNoMatchingAttestations](err); ok {
+		return EventNoMatchingAttestations
+	}
+	if _, ok := errors.AsType[model.UnrecoverableError](err); ok {
+		return EventUnrecoverable
+	}
+	return EventRecoverableError
+}
+
+const (
+	// EventSourceRefAlive means the source ref exists and still points to a live project.
+	EventSourceRefAlive Event = "source_ref_alive"
+	// EventSourceRefStale means the source ref exists but the upstream project no longer does.
+	EventSourceRefStale Event = "source_ref_stale"
+	// EventSourceRefMissing means no source ref exists yet.
+	EventSourceRefMissing Event = "source_ref_missing"
+)
+
+// SourceRefDecision describes the upload worker's next step after checking the
+// existing source ref, if any.
+type SourceRefDecision struct {
+	// ResyncAndReturn updates the image to Resync, records output, and stops.
+	ResyncAndReturn bool
+	// DeleteStale removes a stale source ref before re-uploading.
+	DeleteStale bool
+	// JobStatus is recorded when ResyncAndReturn is true.
+	JobStatus JobStatus
+}
+
+// sourceRefDecisions contains the outcomes for the upload worker's source-ref
+// check phase.
+var sourceRefDecisions = map[Event]SourceRefDecision{
+	// Project is alive in the source: just mark the image for resync and return.
+	EventSourceRefAlive: {
+		ResyncAndReturn: true,
+		JobStatus:       JobStatusSourceRefExists,
+	},
+	// Project is gone from the source: clean up the stale ref and re-upload.
+	EventSourceRefStale: {
+		DeleteStale: true,
+	},
+	// No source ref at all: proceed straight to upload.
+	EventSourceRefMissing: {},
+}
+
+// classifySourceRefEvent turns the source-ref lookup and ProjectExists result
+// into a domain event. It is intentionally pure.
+func classifySourceRefEvent(sourceRefFound bool, projectExists bool) Event {
+	if !sourceRefFound {
+		return EventSourceRefMissing
+	}
+	if projectExists {
+		return EventSourceRefAlive
+	}
+	return EventSourceRefStale
+}
+
+const (
+	// EventTaskInProgress means the upstream processing job is still running.
+	EventTaskInProgress Event = "task_in_progress"
+	// EventTaskComplete means the upstream processing job has finished.
+	EventTaskComplete Event = "task_complete"
+)
+
+// FinalizeDecision describes the finalize worker's next step after checking the
+// upstream processing status.
+type FinalizeDecision struct {
+	// RetryLater returns a normal error so River schedules another attempt.
+	RetryLater bool
+	// MarkResync updates the image to Resync with a ReadyForResyncAt timestamp.
+	MarkResync bool
+	// EnqueueRemovals enqueues RemoveFromSourceJob for any unused refs.
+	EnqueueRemovals bool
+	// JobStatus is recorded on success.
+	JobStatus JobStatus
+}
+
+// finalizeDecisions contains the outcomes for the finalize worker's progress
+// check phase.
+var finalizeDecisions = map[Event]FinalizeDecision{
+	// Still running: return an error so River retries according to its schedule.
+	EventTaskInProgress: {
+		RetryLater: true,
+	},
+	// Done: persist resync state and enqueue cleanup.
+	EventTaskComplete: {
+		MarkResync:      true,
+		EnqueueRemovals: true,
+		JobStatus:       JobStatusUploadAttestationFinalized,
+	},
+}
+
+// classifyFinalizeEvent turns IsTaskInProgress output into a domain event.
+func classifyFinalizeEvent(inProgress bool) Event {
+	if inProgress {
+		return EventTaskInProgress
+	}
+	return EventTaskComplete
+}

--- a/internal/manager/decision_tables.go
+++ b/internal/manager/decision_tables.go
@@ -16,6 +16,7 @@ type Event string
 
 // lookupDecision returns the decision for an event or a descriptive error if the
 // table is missing that event. Workers decide whether that error should cancel
+// the job or be returned for retry.
 func lookupDecision[T any](table map[Event]T, event Event, tableName string) (T, error) {
 	decision, ok := table[event]
 	if ok {

--- a/internal/manager/decision_tables.go
+++ b/internal/manager/decision_tables.go
@@ -27,6 +27,10 @@ func lookupDecision[T any](table map[Event]T, event Event, tableName string) (T,
 	return zero, fmt.Errorf("no %s decision defined for event %q: this is a bug", tableName, event)
 }
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 const (
 	// get_attestation events
 	EventAttestationFound       Event = "attestation_found"
@@ -68,16 +72,16 @@ var getAttestationDecisions = map[Event]Decision{
 	// No matching attestations: mark the workload/image, then let River retry
 	// according to the get_attestation job's MaxAttempts.
 	EventNoMatchingAttestations: {
-		WorkloadState: new(sql.WorkloadStateNoAttestation),
-		ImageState:    new(sql.ImageStateFailed),
+		WorkloadState: ptr(sql.WorkloadStateNoAttestation),
+		ImageState:    ptr(sql.ImageStateFailed),
 		JobStatus:     JobStatusNoAttestation,
 	},
 
 	// Unrecoverable error (e.g. 4xx from registry, invalid image ref).
 	// Mark the workload/image and tell River to stop retrying.
 	EventUnrecoverable: {
-		WorkloadState: new(sql.WorkloadStateUnrecoverable),
-		ImageState:    new(sql.ImageStateFailed),
+		WorkloadState: ptr(sql.WorkloadStateUnrecoverable),
+		ImageState:    ptr(sql.ImageStateFailed),
 		JobStatus:     JobStatusUnrecoverable,
 		CancelJob:     true,
 	},

--- a/internal/manager/decision_tables_test.go
+++ b/internal/manager/decision_tables_test.go
@@ -1,0 +1,322 @@
+package manager
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nais/v13s/internal/attestation"
+	"github.com/nais/v13s/internal/database/sql"
+	"github.com/nais/v13s/internal/model"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+)
+
+func TestClassifyGetAttestationEvent(t *testing.T) {
+	someAtt := &attestation.Attestation{Predicate: []byte(`{}`)}
+
+	tests := []struct {
+		name    string
+		att     *attestation.Attestation
+		err     error
+		wantEvt Event
+	}{
+		{
+			name:    "attestation found",
+			att:     someAtt,
+			err:     nil,
+			wantEvt: EventAttestationFound,
+		},
+		{
+			name:    "no matching attestations",
+			att:     nil,
+			err:     &cosign.ErrNoMatchingAttestations{},
+			wantEvt: EventNoMatchingAttestations,
+		},
+		{
+			name:    "no matching attestations wrapped",
+			att:     nil,
+			err:     fmt.Errorf("wrap: %w", &cosign.ErrNoMatchingAttestations{}),
+			wantEvt: EventNoMatchingAttestations,
+		},
+		{
+			name:    "unrecoverable error",
+			att:     nil,
+			err:     model.ToUnrecoverableError(errors.New("permanent failure"), "attestation"),
+			wantEvt: EventUnrecoverable,
+		},
+		{
+			name:    "recoverable transient error",
+			att:     nil,
+			err:     errors.New("connection timeout"),
+			wantEvt: EventRecoverableError,
+		},
+		{
+			name:    "nil att with nil err is recoverable (unexpected but safe)",
+			att:     nil,
+			err:     nil,
+			wantEvt: EventRecoverableError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyGetAttestationEvent(tc.att, tc.err)
+			if got != tc.wantEvt {
+				t.Errorf("classifyGetAttestationEvent() = %q, want %q", got, tc.wantEvt)
+			}
+		})
+	}
+}
+
+func TestGetAttestationDecisions_Completeness(t *testing.T) {
+	// Every known event must have a decision, no silent fall-throughs.
+	allEvents := []Event{
+		EventAttestationFound,
+		EventNoMatchingAttestations,
+		EventUnrecoverable,
+		EventRecoverableError,
+	}
+	for _, ev := range allEvents {
+		if _, ok := getAttestationDecisions[ev]; !ok {
+			t.Errorf("getAttestationDecisions: missing entry for event %q", ev)
+		}
+	}
+}
+
+func TestGetAttestationDecisions_Correctness(t *testing.T) {
+	noAttest := new(sql.WorkloadStateNoAttestation)
+	unrecov := new(sql.WorkloadStateUnrecoverable)
+	failed := new(sql.ImageStateFailed)
+
+	tests := []struct {
+		event             Event
+		wantWorkloadState *sql.WorkloadState
+		wantImageState    *sql.ImageState
+		wantJobStatus     JobStatus
+		wantCancel        bool
+		wantEnqueueUpload bool
+	}{
+		{
+			event:             EventAttestationFound,
+			wantWorkloadState: nil,
+			wantImageState:    nil,
+			wantJobStatus:     JobStatusAttestationDownloaded,
+			wantCancel:        false,
+			wantEnqueueUpload: true,
+		},
+		{
+			event:             EventNoMatchingAttestations,
+			wantWorkloadState: noAttest,
+			wantImageState:    failed,
+			wantJobStatus:     JobStatusNoAttestation,
+			wantCancel:        false,
+			wantEnqueueUpload: false,
+		},
+		{
+			event:             EventUnrecoverable,
+			wantWorkloadState: unrecov,
+			wantImageState:    failed,
+			wantJobStatus:     JobStatusUnrecoverable,
+			wantCancel:        true,
+			wantEnqueueUpload: false,
+		},
+		{
+			event:             EventRecoverableError,
+			wantWorkloadState: nil,
+			wantImageState:    nil,
+			wantJobStatus:     "",
+			wantCancel:        false,
+			wantEnqueueUpload: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.event), func(t *testing.T) {
+			d, ok := getAttestationDecisions[tc.event]
+			if !ok {
+				t.Fatalf("no decision found for event %q", tc.event)
+			}
+
+			if !workloadStateEqual(d.WorkloadState, tc.wantWorkloadState) {
+				t.Errorf("WorkloadState = %v, want %v", derefWS(d.WorkloadState), derefWS(tc.wantWorkloadState))
+			}
+			if !imageStateEqual(d.ImageState, tc.wantImageState) {
+				t.Errorf("ImageState = %v, want %v", derefIS(d.ImageState), derefIS(tc.wantImageState))
+			}
+			if d.JobStatus != tc.wantJobStatus {
+				t.Errorf("JobStatus = %q, want %q", d.JobStatus, tc.wantJobStatus)
+			}
+			if d.CancelJob != tc.wantCancel {
+				t.Errorf("CancelJob = %v, want %v", d.CancelJob, tc.wantCancel)
+			}
+			if d.EnqueueUpload != tc.wantEnqueueUpload {
+				t.Errorf("EnqueueUpload = %v, want %v", d.EnqueueUpload, tc.wantEnqueueUpload)
+			}
+		})
+	}
+}
+
+func TestLookupDecision_MissingEvent(t *testing.T) {
+	_, err := lookupDecision(getAttestationDecisions, Event("missing"), "get_attestation")
+	if err == nil {
+		t.Fatal("expected error for missing decision")
+	}
+	if got, want := err.Error(), `no get_attestation decision defined for event "missing": this is a bug`; got != want {
+		t.Fatalf("lookupDecision() error = %q, want %q", got, want)
+	}
+}
+
+func TestClassifySourceRefEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		sourceRefFound bool
+		projectExists  bool
+		wantEvt        Event
+	}{
+		{"no source ref", false, false, EventSourceRefMissing},
+		{"source ref exists, project alive", true, true, EventSourceRefAlive},
+		{"source ref exists, project gone", true, false, EventSourceRefStale},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifySourceRefEvent(tc.sourceRefFound, tc.projectExists)
+			if got != tc.wantEvt {
+				t.Errorf("classifySourceRefEvent() = %q, want %q", got, tc.wantEvt)
+			}
+		})
+	}
+}
+
+func TestSourceRefDecisions_Completeness(t *testing.T) {
+	allEvents := []Event{EventSourceRefAlive, EventSourceRefStale, EventSourceRefMissing}
+	for _, ev := range allEvents {
+		if _, ok := sourceRefDecisions[ev]; !ok {
+			t.Errorf("sourceRefDecisions: missing entry for event %q", ev)
+		}
+	}
+}
+
+func TestSourceRefDecisions_Correctness(t *testing.T) {
+	tests := []struct {
+		event               Event
+		wantResyncAndReturn bool
+		wantDeleteStale     bool
+		wantJobStatus       JobStatus
+	}{
+		{EventSourceRefAlive, true, false, JobStatusSourceRefExists},
+		{EventSourceRefStale, false, true, ""},
+		{EventSourceRefMissing, false, false, ""},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.event), func(t *testing.T) {
+			d, ok := sourceRefDecisions[tc.event]
+			if !ok {
+				t.Fatalf("no decision found for event %q", tc.event)
+			}
+			if d.ResyncAndReturn != tc.wantResyncAndReturn {
+				t.Errorf("ResyncAndReturn = %v, want %v", d.ResyncAndReturn, tc.wantResyncAndReturn)
+			}
+			if d.DeleteStale != tc.wantDeleteStale {
+				t.Errorf("DeleteStale = %v, want %v", d.DeleteStale, tc.wantDeleteStale)
+			}
+			if d.JobStatus != tc.wantJobStatus {
+				t.Errorf("JobStatus = %q, want %q", d.JobStatus, tc.wantJobStatus)
+			}
+		})
+	}
+}
+
+func TestClassifyFinalizeEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		inProgress bool
+		wantEvt    Event
+	}{
+		{"task still running", true, EventTaskInProgress},
+		{"task complete", false, EventTaskComplete},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyFinalizeEvent(tc.inProgress)
+			if got != tc.wantEvt {
+				t.Errorf("classifyFinalizeEvent() = %q, want %q", got, tc.wantEvt)
+			}
+		})
+	}
+}
+
+func TestFinalizeDecisions_Completeness(t *testing.T) {
+	allEvents := []Event{EventTaskInProgress, EventTaskComplete}
+	for _, ev := range allEvents {
+		if _, ok := finalizeDecisions[ev]; !ok {
+			t.Errorf("finalizeDecisions: missing entry for event %q", ev)
+		}
+	}
+}
+
+func TestFinalizeDecisions_Correctness(t *testing.T) {
+	tests := []struct {
+		event               Event
+		wantRetryLater      bool
+		wantMarkResync      bool
+		wantEnqueueRemovals bool
+		wantJobStatus       JobStatus
+	}{
+		{EventTaskInProgress, true, false, false, ""},
+		{EventTaskComplete, false, true, true, JobStatusUploadAttestationFinalized},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.event), func(t *testing.T) {
+			d, ok := finalizeDecisions[tc.event]
+			if !ok {
+				t.Fatalf("no decision found for event %q", tc.event)
+			}
+			if d.RetryLater != tc.wantRetryLater {
+				t.Errorf("RetryLater = %v, want %v", d.RetryLater, tc.wantRetryLater)
+			}
+			if d.MarkResync != tc.wantMarkResync {
+				t.Errorf("MarkResync = %v, want %v", d.MarkResync, tc.wantMarkResync)
+			}
+			if d.EnqueueRemovals != tc.wantEnqueueRemovals {
+				t.Errorf("EnqueueRemovals = %v, want %v", d.EnqueueRemovals, tc.wantEnqueueRemovals)
+			}
+			if d.JobStatus != tc.wantJobStatus {
+				t.Errorf("JobStatus = %q, want %q", d.JobStatus, tc.wantJobStatus)
+			}
+		})
+	}
+}
+
+func workloadStateEqual(a, b *sql.WorkloadState) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func imageStateEqual(a, b *sql.ImageState) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func derefWS(s *sql.WorkloadState) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return string(*s)
+}
+
+func derefIS(s *sql.ImageState) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return string(*s)
+}

--- a/internal/manager/decision_tables_test.go
+++ b/internal/manager/decision_tables_test.go
@@ -84,9 +84,9 @@ func TestGetAttestationDecisions_Completeness(t *testing.T) {
 }
 
 func TestGetAttestationDecisions_Correctness(t *testing.T) {
-	noAttest := new(sql.WorkloadStateNoAttestation)
-	unrecov := new(sql.WorkloadStateUnrecoverable)
-	failed := new(sql.ImageStateFailed)
+	noAttest := ptr(sql.WorkloadStateNoAttestation)
+	unrecov := ptr(sql.WorkloadStateUnrecoverable)
+	failed := ptr(sql.ImageStateFailed)
 
 	tests := []struct {
 		event             Event

--- a/internal/manager/delete_workload.go
+++ b/internal/manager/delete_workload.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nais/v13s/internal/database/sql"
 	"github.com/nais/v13s/internal/job"
 	"github.com/nais/v13s/internal/model"
-	"github.com/nais/v13s/internal/sources"
 	"github.com/riverqueue/river"
 	"github.com/sirupsen/logrus"
 )
@@ -36,33 +35,35 @@ func (u DeleteWorkloadJob) InsertOpts() river.InsertOpts {
 }
 
 type DeleteWorkloadWorker struct {
-	db     sql.Querier
-	source sources.Source
-	log    logrus.FieldLogger
+	db  sql.Querier
+	log logrus.FieldLogger
 	river.WorkerDefaults[DeleteWorkloadJob]
 	jobClient job.Client
 }
 
 func (d *DeleteWorkloadWorker) Work(ctx context.Context, job *river.Job[DeleteWorkloadJob]) error {
-	w := job.Args.Workload
-	d.log.WithField("workload", w).Debug("deleting workload")
+	workload := job.Args.Workload
+	d.log.WithField("workload", workload).Debug("deleting workload")
+
+	// Remove the workload row first.
 	_, err := d.db.DeleteWorkload(ctx, sql.DeleteWorkloadParams{
-		Name:         w.Name,
-		Cluster:      w.Cluster,
-		Namespace:    w.Namespace,
-		WorkloadType: string(w.Type),
+		Name:         workload.Name,
+		Cluster:      workload.Cluster,
+		Namespace:    workload.Namespace,
+		WorkloadType: string(workload.Type),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			recordOutput(ctx, JobStatusSourceRefDeleteSkipped)
+			recordStatusOutput(ctx, JobStatusSourceRefDeleteSkipped)
 			return nil
 		}
 		return err
 	}
 
+	// If this image is no longer referenced by any workload, schedule source cleanup.
 	rows, err := d.db.ListWorkloadsByImage(ctx, sql.ListWorkloadsByImageParams{
-		ImageName: w.ImageName,
-		ImageTag:  w.ImageTag,
+		ImageName: workload.ImageName,
+		ImageTag:  workload.ImageTag,
 	})
 	if err != nil {
 		return err
@@ -70,16 +71,16 @@ func (d *DeleteWorkloadWorker) Work(ctx context.Context, job *river.Job[DeleteWo
 
 	if len(rows) == 0 {
 		err = d.jobClient.AddJob(ctx, &RemoveFromSourceJob{
-			ImageName: w.ImageName,
-			ImageTag:  w.ImageTag,
+			ImageName: workload.ImageName,
+			ImageTag:  workload.ImageTag,
 		})
 		if err != nil {
 			d.log.WithError(err).Error("failed to add remove from source job")
 			return err
 		}
-		recordOutput(ctx, JobStatusImageRemovedFromSource)
+		recordStatusOutput(ctx, JobStatusImageRemovedFromSource)
 	} else {
-		recordOutput(ctx, JobStatusImageStillInUse)
+		recordStatusOutput(ctx, JobStatusImageStillInUse)
 	}
 	return nil
 }

--- a/internal/manager/finalize_attestation.go
+++ b/internal/manager/finalize_attestation.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	KindFinalizeAttestation                      = "finalize_attestation"
-	FinalizeAttestationScheduledForResyncMinutes = 10 * time.Second
-	FinalizeAttestationScheduledWaitSecond       = 30 * time.Second
+	KindFinalizeAttestation   = "finalize_attestation"
+	FinalizeAttestationDelay  = 5 * time.Second
+	FinalizeAttestationResync = 10 * time.Second
 )
 
 type FinalizeAttestationJob struct {
@@ -30,7 +30,7 @@ func (FinalizeAttestationJob) Kind() string { return KindFinalizeAttestation }
 func (f FinalizeAttestationJob) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{
 		Queue:       KindFinalizeAttestation,
-		ScheduledAt: time.Now().Add(FinalizeAttestationScheduledWaitSecond),
+		ScheduledAt: time.Now().Add(FinalizeAttestationDelay),
 		UniqueOpts: river.UniqueOpts{
 			ByArgs:   true,
 			ByPeriod: 1 * time.Minute,
@@ -51,16 +51,6 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 	imageName := job.Args.ImageName
 	imageTag := job.Args.ImageTag
 
-	// Check if external processing is complete
-	inProgress, err := f.source.IsTaskInProgress(ctx, job.Args.ProcessToken)
-	if err != nil {
-		return fmt.Errorf("failed to update image state: %w", err)
-	}
-
-	if inProgress {
-		return fmt.Errorf("attestation task for image %s:%s is still in progress", imageName, imageTag)
-	}
-
 	if job.Args.ProcessToken == "" {
 		f.log.WithFields(logrus.Fields{
 			"image": imageName,
@@ -68,35 +58,79 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 		}).Warn("finalizer ran with empty process token, marking for resync anyway")
 	}
 
-	// Mark image as ready for resync
-	err = f.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
-		Name:  imageName,
-		Tag:   imageTag,
-		State: sql.ImageStateResync,
-		ReadyForResyncAt: pgtype.Timestamptz{
-			Time:  time.Now().Add(FinalizeAttestationScheduledForResyncMinutes),
-			Valid: true,
-		},
-	})
+	// 1. Check whether external processing is complete.
+	inProgress, err := f.source.IsTaskInProgress(ctx, job.Args.ProcessToken)
 	if err != nil {
-		return fmt.Errorf("failed to update image state: %f", err)
+		return fmt.Errorf("failed to check task progress: %w", err)
 	}
 
-	rows, err := f.db.ListUnusedSourceRefs(ctx, &imageName)
-	if err != nil {
-		return fmt.Errorf("failed to list unused images: %w", err)
+	// 2. Translate the progress check into a decision.
+	event := classifyFinalizeEvent(inProgress)
+	decision, lookupErr := lookupDecision(finalizeDecisions, event, "finalize_attestation")
+	if lookupErr != nil {
+		return river.JobCancel(lookupErr)
 	}
-	for _, row := range rows {
-		err = f.jobClient.AddJob(ctx, &RemoveFromSourceJob{
-			ImageName: row.ImageName,
-			ImageTag:  row.ImageTag,
+
+	// 3. Still running → return error so River retries on its schedule.
+	if decision.RetryLater {
+		recordStructuredOutput(ctx, JobOutput{
+			Event:    string(event),
+			Decision: "retry_later",
+			Details: map[string]string{
+				"image": imageName,
+				"tag":   imageTag,
+			},
 		})
-		if err != nil {
-			return fmt.Errorf("failed to enqueue RemoveFromSourceJob for %s:%s: %w",
-				row.ImageName, row.ImageTag, err)
+		return fmt.Errorf("attestation task for image %s:%s is still in progress", imageName, imageTag)
+	}
+
+	// 4. Mark image as ready for resync.
+	if decision.MarkResync {
+		if err := f.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:  imageName,
+			Tag:   imageTag,
+			State: sql.ImageStateResync,
+			ReadyForResyncAt: pgtype.Timestamptz{
+				Time:  time.Now().Add(FinalizeAttestationResync),
+				Valid: true,
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to update image state: %w", err)
 		}
 	}
 
-	recordOutput(ctx, JobStatusUploadAttestationFinalized)
+	// 5. Enqueue cleanup for unused source refs.
+	removalCount := 0
+	if decision.EnqueueRemovals {
+		rows, err := f.db.ListUnusedSourceRefs(ctx, &imageName)
+		if err != nil {
+			return fmt.Errorf("failed to list unused images: %w", err)
+		}
+		removalCount = len(rows)
+		for _, row := range rows {
+			if err := f.jobClient.AddJob(ctx, &RemoveFromSourceJob{
+				ImageName: row.ImageName,
+				ImageTag:  row.ImageTag,
+			}); err != nil {
+				return fmt.Errorf("failed to enqueue RemoveFromSourceJob for %s:%s: %w",
+					row.ImageName, row.ImageTag, err)
+			}
+		}
+	}
+
+	// 6. Record River job output.
+	if decision.JobStatus != "" {
+		recordStructuredOutput(ctx, JobOutput{
+			Status:   decision.JobStatus,
+			Event:    string(event),
+			Decision: "mark_resync_and_cleanup",
+			Details: map[string]string{
+				"image":             imageName,
+				"tag":               imageTag,
+				"removals_enqueued": fmt.Sprint(removalCount),
+			},
+		})
+	}
+
 	return nil
 }

--- a/internal/manager/finalize_attestation.go
+++ b/internal/manager/finalize_attestation.go
@@ -51,7 +51,9 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 	imageName := job.Args.ImageName
 	imageTag := job.Args.ImageTag
 
-	if job.Args.ProcessToken == "" {
+	processToken := job.Args.ProcessToken
+
+	if processToken == "" {
 		f.log.WithFields(logrus.Fields{
 			"image": imageName,
 			"tag":   imageTag,
@@ -59,13 +61,18 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 	}
 
 	// 1. Check whether external processing is complete.
-	inProgress, err := f.source.IsTaskInProgress(ctx, job.Args.ProcessToken)
-	if err != nil {
-		return fmt.Errorf("failed to check task progress: %w", err)
+	// Empty tokens are treated as complete to avoid source-specific parse errors
+	// (e.g. dependencytrack expects UUID process tokens).
+	event := EventTaskComplete
+	if processToken != "" {
+		inProgress, err := f.source.IsTaskInProgress(ctx, processToken)
+		if err != nil {
+			return fmt.Errorf("failed to check task progress: %w", err)
+		}
+		event = classifyFinalizeEvent(inProgress)
 	}
 
 	// 2. Translate the progress check into a decision.
-	event := classifyFinalizeEvent(inProgress)
 	decision, lookupErr := lookupDecision(finalizeDecisions, event, "finalize_attestation")
 	if lookupErr != nil {
 		return river.JobCancel(lookupErr)

--- a/internal/manager/get_attestation.go
+++ b/internal/manager/get_attestation.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/nais/v13s/internal/job"
 	"github.com/nais/v13s/internal/model"
 	"github.com/riverqueue/river"
-	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -41,7 +39,7 @@ func (g GetAttestationJob) InsertOpts() river.InsertOpts {
 			ByArgs:   true,
 			ByPeriod: 1 * time.Minute,
 		},
-		MaxAttempts: 3,
+		MaxAttempts: 4,
 	}
 }
 
@@ -62,119 +60,123 @@ func (g *GetAttestationWorker) Work(ctx context.Context, job *river.Job[GetAttes
 	ctx, span := otel.Tracer("v13s/get-attestation").Start(ctx, "GetAttestationWorker.Work")
 	defer span.End()
 
+	imageName := job.Args.ImageName
+	imageTag := job.Args.ImageTag
+
 	span.SetAttributes(
-		attribute.String("image.name", job.Args.ImageName),
-		attribute.String("image.tag", job.Args.ImageTag),
+		attribute.String("image.name", imageName),
+		attribute.String("image.tag", imageTag),
 		attribute.String("workload.id", job.Args.WorkloadId.String()),
 	)
 
-	imageName := job.Args.ImageName
-	imageTag := job.Args.ImageTag
+	logFields := logrus.Fields{
+		"image":         imageName,
+		"tag":           imageTag,
+		"workloadId":    job.Args.WorkloadId,
+		"workload_type": job.Args.WorkloadType,
+	}
+
+	// 1. Call external verifier.
 	att, err := g.verifier.GetAttestation(ctx, fmt.Sprintf("%s:%s", imageName, imageTag))
-	g.workloadCounter.Add(
-		ctx,
-		1,
-		metric.WithAttributes(
-			attribute.String("hasAttestation", fmt.Sprint(att != nil)),
-		))
+	g.workloadCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("hasAttestation", fmt.Sprint(att != nil)),
+	))
 
-	runDB := func(fn func(dbCtx context.Context) error) error {
-		dbCtx, cancel := context.WithTimeout(ctx, attestationDBTimeout)
-		defer cancel()
-		return fn(dbCtx)
+	// 2. Classify the verifier result into a domain event.
+	event := classifyGetAttestationEvent(att, err)
+
+	// 3. Translate the event into a decision.
+	decision, lookupErr := lookupDecision(getAttestationDecisions, event, "get_attestation")
+	if lookupErr != nil {
+		return river.JobCancel(lookupErr)
 	}
 
-	if err != nil {
-		if noMatchAttestationError, ok := errors.AsType[*cosign.ErrNoMatchingAttestations](err); ok {
-			// No matching attestations is a terminal but expected state for many images.
-			g.log.WithError(err).WithFields(logrus.Fields{
-				"image":         imageName,
-				"tag":           imageTag,
-				"workloadId":    job.Args.WorkloadId,
-				"workload_type": job.Args.WorkloadType,
-			}).Info("no attestations found for workload image")
-
-			if dbErr := runDB(func(dbCtx context.Context) error {
-				return g.db.UpdateWorkloadState(dbCtx, sql.UpdateWorkloadStateParams{
-					State: sql.WorkloadStateNoAttestation,
-					ID:    job.Args.WorkloadId,
-				})
-			}); dbErr != nil {
-				return fmt.Errorf("failed to set workload state: %w", dbErr)
-			}
-
-			if dbErr := runDB(func(dbCtx context.Context) error {
-				return g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
-					State: sql.ImageStateFailed,
-					Name:  imageName,
-					Tag:   imageTag,
-				})
-			}); dbErr != nil {
-				return fmt.Errorf("failed to set image state: %w", dbErr)
-			}
-
-			recordOutput(ctx, JobStatusNoAttestation)
-			span.SetStatus(codes.Ok, "no attestation found")
-			// Always cancel the job so River does not keep retrying this expected condition.
-			return handleJobErr(noMatchAttestationError)
-		} else if unrecoverableError, ok := errors.AsType[model.UnrecoverableError](err); ok {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			g.log.WithFields(
-				logrus.Fields{
-					"image":      imageName,
-					"tag":        imageTag,
-					"workloadId": job.Args.WorkloadId,
-				},
-			).Info("marking workload and image as unrecoverable due to unrecoverable error from attestation source")
-			recordOutput(ctx, JobStatusUnrecoverable)
-
-			if dbErr := runDB(func(dbCtx context.Context) error {
-				return g.db.UpdateWorkloadState(dbCtx, sql.UpdateWorkloadStateParams{
-					State: sql.WorkloadStateUnrecoverable,
-					ID:    job.Args.WorkloadId,
-				})
-			}); dbErr != nil {
-				return fmt.Errorf("failed to set workload state: %w", dbErr)
-			}
-			if dbErr := runDB(func(dbCtx context.Context) error {
-				return g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
-					State: sql.ImageStateFailed,
-					Name:  imageName,
-					Tag:   imageTag,
-				})
-			}); dbErr != nil {
-				return fmt.Errorf("failed to set image state: %w", dbErr)
-			}
-			return river.JobCancel(unrecoverableError)
-		}
-
-		return handleJobErr(err)
+	// 4. Log event-specific context.
+	switch event {
+	case EventNoMatchingAttestations:
+		g.log.WithError(err).WithFields(logFields).Info("no attestations found for workload image")
+	case EventUnrecoverable:
+		g.log.WithFields(logFields).Info("marking workload and image as unrecoverable due to unrecoverable error from attestation source")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
-	if att != nil {
-		compressed, err := att.Compress()
-		if err != nil {
-			return fmt.Errorf("failed to compress attestation: %w", err)
+
+	// 5. Apply DB state changes in a single timeout context.
+	dbCtx, cancel := context.WithTimeout(ctx, attestationDBTimeout)
+	defer cancel()
+
+	if decision.WorkloadState != nil {
+		if dbErr := g.db.UpdateWorkloadState(dbCtx, sql.UpdateWorkloadStateParams{
+			State: *decision.WorkloadState,
+			ID:    job.Args.WorkloadId,
+		}); dbErr != nil {
+			return fmt.Errorf("failed to set workload state: %w", dbErr)
 		}
-		if err := g.jobClient.AddJob(ctx, &UploadAttestationJob{
+	}
+
+	if decision.ImageState != nil {
+		if dbErr := g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
+			State: *decision.ImageState,
+			Name:  imageName,
+			Tag:   imageTag,
+		}); dbErr != nil {
+			return fmt.Errorf("failed to set image state: %w", dbErr)
+		}
+	}
+
+	// 6. Enqueue the next River job if the decision requires it.
+	if decision.EnqueueUpload && att != nil {
+		compressed, compErr := att.Compress()
+		if compErr != nil {
+			return fmt.Errorf("failed to compress attestation: %w", compErr)
+		}
+		if enqErr := g.jobClient.AddJob(ctx, &UploadAttestationJob{
 			ImageName:   imageName,
 			ImageTag:    imageTag,
 			WorkloadId:  job.Args.WorkloadId,
 			Attestation: compressed,
-		}); err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			return err
+		}); enqErr != nil {
+			span.RecordError(enqErr)
+			span.SetStatus(codes.Error, enqErr.Error())
+			return enqErr
 		}
-		recordOutput(ctx, JobStatusAttestationDownloaded)
-		g.log.WithFields(logrus.Fields{
-			"image":         imageName,
-			"tag":           imageTag,
-			"workloadId":    job.Args.WorkloadId,
-			"workload_type": job.Args.WorkloadType,
-		}).Debug("attestation downloaded and upload_attestation job enqueued")
+		g.log.WithFields(logFields).Debug("attestation downloaded and upload_attestation job enqueued")
+	}
+
+	// 7. Record River job output with decision trace.
+	if decision.JobStatus != "" {
+		retry := !decision.CancelJob
+		recordStructuredOutput(ctx, JobOutput{
+			Status:    decision.JobStatus,
+			Event:     string(event),
+			Decision:  describeGetAttestationDecision(decision),
+			Retryable: &retry,
+			Details: map[string]string{
+				"image":   imageName,
+				"tag":     imageTag,
+				"enqueue": fmt.Sprint(decision.EnqueueUpload),
+			},
+		})
+	}
+
+	// 8. Cancel River retries for terminal events; let River retry for recoverable errors.
+	if decision.CancelJob {
+		return river.JobCancel(err)
 	}
 
 	span.SetStatus(codes.Ok, "attestation processing complete")
-	return nil
+	return err // nil on success; non-nil recoverable error triggers River retry
+}
+
+func describeGetAttestationDecision(d Decision) string {
+	if d.EnqueueUpload {
+		return "enqueue_upload"
+	}
+	if d.CancelJob {
+		return "cancel"
+	}
+	if d.WorkloadState != nil || d.ImageState != nil {
+		return "update_state"
+	}
+	return "retry"
 }

--- a/internal/manager/job_output.go
+++ b/internal/manager/job_output.go
@@ -10,7 +10,11 @@ import (
 )
 
 type JobOutput struct {
-	Status JobStatus `json:"status"`
+	Status    JobStatus         `json:"status"`
+	Event     string            `json:"event,omitempty"`     // domain event that triggered the decision
+	Decision  string            `json:"decision,omitempty"`  // what was decided (retry, cancel, upload, mark_resync, etc)
+	Retryable *bool             `json:"retryable,omitempty"` // whether the job will be retried
+	Details   map[string]string `json:"details,omitempty"`   // context: image, tag, token_present, etc
 }
 
 type JobStatus = string
@@ -30,12 +34,22 @@ const (
 	JobStatusSourceRefDeleted           JobStatus = "source_ref_deleted"
 )
 
-func recordOutput(ctx context.Context, status JobStatus) {
+func recordStatusOutput(ctx context.Context, status JobStatus) {
 	err := river.RecordOutput(ctx, JobOutput{
 		Status: status,
 	})
 	if err != nil {
 		logrus.Error("failed to record job output: %w", err)
+	}
+}
+
+func recordStructuredOutput(ctx context.Context, out JobOutput) {
+	if out.Status == "" && out.Event == "" && out.Decision == "" && len(out.Details) == 0 {
+		logrus.Warn("recordStructuredOutput called with no status, event, decision, or details")
+	}
+	err := river.RecordOutput(ctx, out)
+	if err != nil {
+		logrus.WithError(err).Error("failed to record structured job output")
 	}
 }
 

--- a/internal/manager/job_output.go
+++ b/internal/manager/job_output.go
@@ -44,7 +44,7 @@ func recordStatusOutput(ctx context.Context, status JobStatus) {
 }
 
 func recordStructuredOutput(ctx context.Context, out JobOutput) {
-	if out.Status == "" && out.Event == "" && out.Decision == "" && len(out.Details) == 0 {
+	if out.Status == "" && out.Event == "" && out.Decision == "" && out.Retryable == nil && len(out.Details) == 0 {
 		logrus.Warn("recordStructuredOutput called with no status, event, decision, or details")
 	}
 	err := river.RecordOutput(ctx, out)

--- a/internal/manager/job_output.go
+++ b/internal/manager/job_output.go
@@ -39,7 +39,7 @@ func recordStatusOutput(ctx context.Context, status JobStatus) {
 		Status: status,
 	})
 	if err != nil {
-		logrus.Error("failed to record job output: %w", err)
+		logrus.WithError(err).Error("failed to record job output")
 	}
 }
 

--- a/internal/manager/remove_from_source.go
+++ b/internal/manager/remove_from_source.go
@@ -69,6 +69,6 @@ func (r *RemoveFromSourceWorker) Work(ctx context.Context, job *river.Job[Remove
 		return handleJobErr(err)
 	}
 
-	recordOutput(ctx, JobStatusSourceRefDeleted)
+	recordStatusOutput(ctx, JobStatusSourceRefDeleted)
 	return nil
 }

--- a/internal/manager/upload_attestation.go
+++ b/internal/manager/upload_attestation.go
@@ -56,50 +56,29 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 	ctx, span := otel.Tracer("v13s/upload-attestation").Start(ctx, "UploadAttestationWorker")
 	defer span.End()
 
-	span.SetAttributes(
-		attribute.String("image.name", job.Args.ImageName),
-		attribute.String("image.tag", job.Args.ImageTag),
-		attribute.String("workload.id", job.Args.WorkloadId.String()),
-	)
-
 	imageName := job.Args.ImageName
 	imageTag := job.Args.ImageTag
 
-	sourceRef, err := u.db.GetSourceRef(ctx, sql.GetSourceRefParams{
-		ImageName:  imageName,
-		ImageTag:   imageTag,
-		SourceType: u.source.Name(),
-	})
+	span.SetAttributes(
+		attribute.String("image.name", imageName),
+		attribute.String("image.tag", imageTag),
+		attribute.String("workload.id", job.Args.WorkloadId.String()),
+	)
 
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return fmt.Errorf("failed to check source ref: %w", err)
+	// 1. Check source-ref state and classify the result.
+	sourceRefFound, projectExists, err := u.checkSourceRef(ctx, imageName, imageTag)
+	if err != nil {
+		return err // recoverable; River retries
 	}
 
-	if err == nil {
-		// sourceRef exists → check if the project actually exists
-		exists, err := u.source.ProjectExists(ctx, sourceRef.ImageName, sourceRef.ImageTag)
-		if err != nil {
-			return fmt.Errorf("failed to verify project existence: %w", err)
-		}
-		if exists {
-			err = u.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
-				Name:  imageName,
-				Tag:   imageTag,
-				State: sql.ImageStateResync,
-				ReadyForResyncAt: pgtype.Timestamptz{
-					Time:  time.Now(),
-					Valid: true,
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("failed to update image state: %w", err)
-			}
+	sourceRefEvent := classifySourceRefEvent(sourceRefFound, projectExists)
+	sourceRefDecision, lookupErr := lookupDecision(sourceRefDecisions, sourceRefEvent, "upload_attestation source_ref")
+	if lookupErr != nil {
+		return river.JobCancel(lookupErr)
+	}
 
-			recordOutput(ctx, JobStatusSourceRefExists)
-			return nil
-		}
-
-		// project does not exist → delete stale sourceRef
+	// 2. Apply source-ref decision side effects.
+	if sourceRefDecision.DeleteStale {
 		if err := u.db.DeleteSourceRef(ctx, sql.DeleteSourceRefParams{
 			ImageName:  imageName,
 			ImageTag:   imageTag,
@@ -113,54 +92,103 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 		}).Warn("deleted stale sourceRef; will attempt to create new project")
 	}
 
+	if sourceRefDecision.ResyncAndReturn {
+		if err := u.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:  imageName,
+			Tag:   imageTag,
+			State: sql.ImageStateResync,
+			ReadyForResyncAt: pgtype.Timestamptz{
+				Time:  time.Now(),
+				Valid: true,
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to update image state: %w", err)
+		}
+		recordStructuredOutput(ctx, JobOutput{
+			Status:   sourceRefDecision.JobStatus,
+			Event:    string(sourceRefEvent),
+			Decision: "resync_and_return",
+			Details: map[string]string{
+				"image": imageName,
+				"tag":   imageTag,
+			},
+		})
+		return nil
+	}
+
+	// 3. Decompress the attestation payload.
 	att, err := attestation.Decompress(job.Args.Attestation)
 	if err != nil {
 		return fmt.Errorf("failed to decompress attestation: %w", err)
 	}
 
-	// Upload attestation and create new sourceRef
+	// 4. Upload attestation to the source.
+	// TODO: consider a table to track persistent upload failures for team alerting.
 	uploadRes, upErr := u.source.UploadAttestation(ctx, imageName, imageTag, att.Predicate)
 	if upErr != nil {
 		span.RecordError(upErr)
 		span.SetStatus(codes.Error, "failed to upload attestation to source")
-		// TODO: consider creating a table to track sbom upload failures
-		// can be used to alert teams of persistent upload failures
-		// now we just delete the dangling project and try again
 		return handleJobErr(upErr)
 	}
 
-	err = u.db.CreateSourceRef(ctx, sql.CreateSourceRefParams{
-		SourceID: pgtype.UUID{
-			Bytes: uploadRes.AttestationId,
-			Valid: true,
+	// 5. Persist upload results.
+	if err := u.db.CreateSourceRef(ctx, sql.CreateSourceRefParams{
+		SourceID:   pgtype.UUID{Bytes: uploadRes.AttestationId, Valid: true},
+		ImageName:  imageName,
+		ImageTag:   imageTag,
+		SourceType: u.source.Name(),
+	}); err != nil {
+		return err
+	}
+
+	if err := u.db.UpdateImage(ctx, sql.UpdateImageParams{
+		Name:     imageName,
+		Tag:      imageTag,
+		Metadata: att.Metadata,
+	}); err != nil {
+		return fmt.Errorf("failed to update image metadata: %w", err)
+	}
+
+	// 6. Enqueue the finalize job.
+	if err := u.jobClient.AddJob(ctx, &FinalizeAttestationJob{
+		ImageName:    imageName,
+		ImageTag:     imageTag,
+		ProcessToken: uploadRes.ProcessToken,
+	}); err != nil {
+		return fmt.Errorf("failed to enqueue finalize attestation job: %w", err)
+	}
+
+	recordStructuredOutput(ctx, JobOutput{
+		Status:   JobStatusAttestationUploaded,
+		Event:    string(sourceRefEvent),
+		Decision: "upload_and_enqueue_finalize",
+		Details: map[string]string{
+			"image":                imageName,
+			"tag":                  imageTag,
+			"process_token_exists": fmt.Sprint(uploadRes.ProcessToken != ""),
 		},
+	})
+	return nil
+}
+
+// checkSourceRef looks up an existing source ref for the image and checks whether
+// its upstream project is still alive. Returns (found, projectExists, error).
+func (u *UploadAttestationWorker) checkSourceRef(ctx context.Context, imageName, imageTag string) (found bool, projectExists bool, err error) {
+	sourceRef, err := u.db.GetSourceRef(ctx, sql.GetSourceRefParams{
 		ImageName:  imageName,
 		ImageTag:   imageTag,
 		SourceType: u.source.Name(),
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, false, nil
+	}
 	if err != nil {
-		return err
+		return false, false, fmt.Errorf("failed to check source ref: %w", err)
 	}
 
-	err = u.db.UpdateImage(ctx, sql.UpdateImageParams{
-		Name:     imageName,
-		Tag:      imageTag,
-		Metadata: att.Metadata,
-	})
+	exists, err := u.source.ProjectExists(ctx, sourceRef.ImageName, sourceRef.ImageTag)
 	if err != nil {
-		return fmt.Errorf("failed to set ReadyForResyncAt: %w", err)
+		return true, false, fmt.Errorf("failed to verify project existence: %w", err)
 	}
-
-	// enqueue finalize job
-	err = u.jobClient.AddJob(ctx, &FinalizeAttestationJob{
-		ImageName:    imageName,
-		ImageTag:     imageTag,
-		ProcessToken: uploadRes.ProcessToken,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to enqueue finalize attestation job: %w", err)
-	}
-
-	recordOutput(ctx, JobStatusAttestationUploaded)
-	return nil
+	return true, exists, nil
 }

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -69,7 +69,7 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 	job.AddWorker(jobClient, &GetAttestationWorker{db: db, verifier: verifier, jobClient: jobClient, workloadCounter: udCounter, log: log.WithField("subsystem", "get_attestation")})
 	job.AddWorker(jobClient, &UploadAttestationWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "upload_attestation")})
 	job.AddWorker(jobClient, &RemoveFromSourceWorker{db: db, source: source, log: log.WithField("subsystem", "remove_from_source")})
-	job.AddWorker(jobClient, &DeleteWorkloadWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "delete_workload")})
+	job.AddWorker(jobClient, &DeleteWorkloadWorker{db: db, jobClient: jobClient, log: log.WithField("subsystem", "delete_workload")})
 	job.AddWorker(jobClient, &FinalizeAttestationWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "finalize_attestation")})
 	m := &WorkloadManager{
 		db:              db,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -114,7 +114,6 @@ func LoadWorkloadMetrics(ctx context.Context, pool *pgxpool.Pool, log logrus.Fie
 	const pageSize = 300
 	offset := int32(0)
 
-
 	rows := make([]metricRow, 0, pageSize)
 
 	for {
@@ -140,20 +139,20 @@ func LoadWorkloadMetrics(ctx context.Context, pool *pgxpool.Pool, log logrus.Fie
 		for _, row := range summaries {
 			rows = append(rows, metricRow{
 				workload: sql.ListWorkloadsByImageRow{
-					Cluster:   row.Cluster,
-					Namespace: row.Namespace,
-					Name:      row.WorkloadName,
+					Cluster:      row.Cluster,
+					Namespace:    row.Namespace,
+					Name:         row.WorkloadName,
 					WorkloadType: row.WorkloadType,
-					ImageName: row.CurrentImageName,
-					ImageTag:  row.CurrentImageTag,
+					ImageName:    row.CurrentImageName,
+					ImageTag:     row.CurrentImageTag,
 				},
 				summary: sources.VulnerabilitySummary{
-				Critical:   safeInt(row.Critical),
-				High:       safeInt(row.High),
-				Medium:     safeInt(row.Medium),
-				Low:        safeInt(row.Low),
-				Unassigned: safeInt(row.Unassigned),
-				RiskScore:  safeInt(row.RiskScore),
+					Critical:   safeInt(row.Critical),
+					High:       safeInt(row.High),
+					Medium:     safeInt(row.Medium),
+					Low:        safeInt(row.Low),
+					Unassigned: safeInt(row.Unassigned),
+					RiskScore:  safeInt(row.RiskScore),
 				},
 			})
 		}

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -402,7 +402,7 @@ func TestUpdater(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Set ReadyForResyncAt to 5 minutes ago
-		readyAt := time.Now().Add(-manager.FinalizeAttestationScheduledForResyncMinutes)
+		readyAt := time.Now().Add(-manager.FinalizeAttestationResync)
 		err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  imageName,
 			Tag:   imageTag,

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -401,7 +401,6 @@ func TestUpdater(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		// Set ReadyForResyncAt to 5 minutes ago
 		readyAt := time.Now().Add(-manager.FinalizeAttestationResync)
 		err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  imageName,


### PR DESCRIPTION
This pull request introduces a significant refactor and test coverage for decision logic in the workload attestation and image management pipeline. The main change is the introduction of explicit, table-driven decision tables for worker steps, which improves maintainability, clarity, and testability. Additionally, some minor improvements and cleanups are made to error handling, logging, and configuration.

**Decision Table Refactor and Test Coverage**

* Introduced `internal/manager/decision_tables.go`, which defines explicit, type-safe decision tables and event classification functions for attestation, source ref, and finalize steps. This centralizes all state transition logic and makes it easier to reason about and update.
* Added comprehensive unit tests in `internal/manager/decision_tables_test.go` to verify correctness and completeness of the new decision tables and event classification logic.

**Worker and Logging Improvements**

* Updated `internal/manager/add_workload.go` to use `recordStatusOutput` instead of the deprecated `recordOutput`, and commented out a noisy debug log for already-initialized workloads. [[1]](diffhunk://#diff-fc46141387e98b8e43269fb2607fec64eab052257dec0a83d394fb8af57ae2b4L67-R68) [[2]](diffhunk://#diff-fc46141387e98b8e43269fb2607fec64eab052257dec0a83d394fb8af57ae2b4L95-R95)
* Refactored `internal/manager/delete_workload.go` to remove an unused dependency, improve variable naming, and consistently use `recordStatusOutput` for job status updates. [[1]](diffhunk://#diff-f5e15d7bf1e933adb794875b39c7b29010d41be3d6ef4855a1c82d944298140fL12) [[2]](diffhunk://#diff-f5e15d7bf1e933adb794875b39c7b29010d41be3d6ef4855a1c82d944298140fL40-R83)

**Configuration and Metrics**

* Changed the log field for metrics loading in `internal/api/api.go` from `metrics-push` to `metrics-load` for clarity.

**Job Scheduling Consistency**

* Renamed and standardized constants for finalize attestation job scheduling delays in `internal/manager/finalize_attestation.go` for clarity and consistency. [[1]](diffhunk://#diff-4beb45dc98b47ffa6bdf2c728de6120d5a884a7e539b2ab96e13d7a2dcfb910bL18-R19) [[2]](diffhunk://#diff-4beb45dc98b47ffa6bdf2c728de6120d5a884a7e539b2ab96e13d7a2dcfb910bL33-R33)

**Prometheus Rule Action Text**

* Improved the remediation steps in the Prometheus rule alert action text to be more actionable and step-by-step.