### PR TITLE
Fix/mark untracked workload check

### DIFF
--- a/internal/database/migrations/0023_idx_images_state_untracked.sql
+++ b/internal/database/migrations/0023_idx_images_state_untracked.sql
@@ -1,0 +1,13 @@
+-- +goose NO TRANSACTION
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- The "NO TRANSACTION" directive tells goose to run this migration outside
+-- of a transaction, which is required for CONCURRENTLY to work correctly.
+
+-- +goose Up
+-- Add partial index on images.state for efficient untracked image recovery
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_images_state_untracked ON images(state)
+WHERE
+    state = 'untracked';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_images_state_untracked;

--- a/internal/database/migrations/0023_idx_images_state_untracked.sql
+++ b/internal/database/migrations/0023_idx_images_state_untracked.sql
@@ -2,7 +2,6 @@
 -- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
 -- The "NO TRANSACTION" directive tells goose to run this migration outside
 -- of a transaction, which is required for CONCURRENTLY to work correctly.
-
 -- +goose Up
 -- Add partial index on images.state for efficient untracked image recovery
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_images_state_untracked ON images(state)

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -71,7 +71,15 @@ SET
     updated_at = NOW()
 WHERE
     state = ANY (@included_states::image_state[])
-    AND updated_at < @threshold_time;
+    AND updated_at < @threshold_time
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            workloads
+        WHERE
+            image_name = images.name
+            AND image_tag = images.tag);
 
 -- name: MarkUnusedImages :execrows
 UPDATE

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -70,8 +70,9 @@ SET
     state = 'untracked',
     updated_at = NOW()
 WHERE
-    state = ANY (@included_states::image_state[])
-    AND updated_at < @threshold_time
+    images.state = ANY (@included_states::image_state[])
+    AND images.updated_at < @threshold_time
+    AND images.ready_for_resync_at IS NULL
     AND EXISTS (
         SELECT
             1
@@ -134,6 +135,24 @@ WHERE
     AND images.updated_at < @threshold_time
     AND images.state != 'resync'
     AND images.state != ANY (@excluded_states::image_state[]);
+
+-- name: MarkUntrackedImagesForResync :execrows
+UPDATE
+    images
+SET
+    state = 'resync',
+    ready_for_resync_at = NOW(),
+    updated_at = NOW()
+WHERE
+    state = 'untracked'
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            workloads
+        WHERE
+            image_name = images.name
+            AND image_tag = images.tag);
 
 -- name: UpdateImageSyncStatus :exec
 INSERT INTO image_sync_status(

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -58,6 +58,7 @@ UPDATE
     images
 SET
     state = @state,
+    ready_for_resync_at = NULL,
     updated_at = NOW()
 WHERE
     name = @name

--- a/internal/database/sql/batch.go
+++ b/internal/database/sql/batch.go
@@ -21,6 +21,7 @@ UPDATE
     images
 SET
     state = $1,
+    ready_for_resync_at = NULL,
     updated_at = NOW()
 WHERE
     name = $2

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -161,6 +161,14 @@ SET
 WHERE
     state = ANY ($1::image_state[])
     AND updated_at < $2
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            workloads
+        WHERE
+            image_name = images.name
+            AND image_tag = images.tag)
 `
 
 type MarkImagesAsUntrackedParams struct {

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -18,8 +18,8 @@ INSERT INTO images(
 VALUES (
     $1,
     $2,
-    COALESCE($3, '{}'::jsonb)
-)
+    COALESCE(
+        $3, '{}' ::JSONB))
 ON CONFLICT
     DO NOTHING
 `
@@ -159,8 +159,9 @@ SET
     state = 'untracked',
     updated_at = NOW()
 WHERE
-    state = ANY ($1::image_state[])
-    AND updated_at < $2
+    images.state = ANY ($1::image_state[])
+    AND images.updated_at < $2
+    AND images.ready_for_resync_at IS NULL
     AND EXISTS (
         SELECT
             1
@@ -210,6 +211,33 @@ func (q *Queries) MarkImagesForResync(ctx context.Context, arg MarkImagesForResy
 	return err
 }
 
+const markUntrackedImagesForResync = `-- name: MarkUntrackedImagesForResync :execrows
+UPDATE
+    images
+SET
+    state = 'resync',
+    ready_for_resync_at = NOW(),
+    updated_at = NOW()
+WHERE
+    state = 'untracked'
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            workloads
+        WHERE
+            image_name = images.name
+            AND image_tag = images.tag)
+`
+
+func (q *Queries) MarkUntrackedImagesForResync(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, markUntrackedImagesForResync)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const markUnusedImages = `-- name: MarkUnusedImages :execrows
 UPDATE
     images
@@ -247,7 +275,7 @@ const updateImage = `-- name: UpdateImage :exec
 UPDATE
     images
 SET
-    metadata = COALESCE($1, '{}'::jsonb),
+    metadata = COALESCE($1, '{}'::JSONB),
     updated_at = NOW()
 WHERE
     name = $2

--- a/internal/database/sql/querier.go
+++ b/internal/database/sql/querier.go
@@ -60,6 +60,7 @@ type Querier interface {
 	ListWorkloadsForVulnerabilityById(ctx context.Context, vulnerabilityID pgtype.UUID) ([]*ListWorkloadsForVulnerabilityByIdRow, error)
 	MarkImagesAsUntracked(ctx context.Context, arg MarkImagesAsUntrackedParams) (int64, error)
 	MarkImagesForResync(ctx context.Context, arg MarkImagesForResyncParams) error
+	MarkUntrackedImagesForResync(ctx context.Context) (int64, error)
 	MarkUnusedImages(ctx context.Context, arg MarkUnusedImagesParams) (int64, error)
 	RecalculateVulnerabilitySummary(ctx context.Context, arg RecalculateVulnerabilitySummaryParams) error
 	RefreshVulnerabilitySummaryDailyView(ctx context.Context) error

--- a/internal/mocks/Querier/mock_querier.go
+++ b/internal/mocks/Querier/mock_querier.go
@@ -2845,6 +2845,62 @@ func (_c *MockQuerier_MarkImagesForResync_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// MarkUntrackedImagesForResync provides a mock function with given fields: ctx
+func (_m *MockQuerier) MarkUntrackedImagesForResync(ctx context.Context) (int64, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkUntrackedImagesForResync")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (int64, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) int64); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_MarkUntrackedImagesForResync_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkUntrackedImagesForResync'
+type MockQuerier_MarkUntrackedImagesForResync_Call struct {
+	*mock.Call
+}
+
+// MarkUntrackedImagesForResync is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockQuerier_Expecter) MarkUntrackedImagesForResync(ctx interface{}) *MockQuerier_MarkUntrackedImagesForResync_Call {
+	return &MockQuerier_MarkUntrackedImagesForResync_Call{Call: _e.mock.On("MarkUntrackedImagesForResync", ctx)}
+}
+
+func (_c *MockQuerier_MarkUntrackedImagesForResync_Call) Run(run func(ctx context.Context)) *MockQuerier_MarkUntrackedImagesForResync_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_MarkUntrackedImagesForResync_Call) Return(_a0 int64, _a1 error) *MockQuerier_MarkUntrackedImagesForResync_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_MarkUntrackedImagesForResync_Call) RunAndReturn(run func(context.Context) (int64, error)) *MockQuerier_MarkUntrackedImagesForResync_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarkUnusedImages provides a mock function with given fields: ctx, arg
 func (_m *MockQuerier) MarkUnusedImages(ctx context.Context, arg sql.MarkUnusedImagesParams) (int64, error) {
 	ret := _m.Called(ctx, arg)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -66,7 +66,6 @@ func (u *Updater) Run(ctx context.Context) {
 	go runScheduled(ctx, u.updateSchedule, "mark and resync images and sync workload vulnerabilities", u.log, func() {
 		if err := u.RecoverUntrackedImages(ctx); err != nil {
 			u.log.WithError(err).Error("Failed to recover untracked images")
-			return
 		}
 		if err := u.MarkForResync(ctx); err != nil {
 			u.log.WithError(err).Error("Failed to mark images for resync")

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -64,6 +64,10 @@ func NewUpdater(pool *pgxpool.Pool, source sources.Source, mgr *manager.Workload
 // Run TODO: create a state/log table and log errors? maybe successfull and failed runs?
 func (u *Updater) Run(ctx context.Context) {
 	go runScheduled(ctx, u.updateSchedule, "mark and resync images and sync workload vulnerabilities", u.log, func() {
+		if err := u.RecoverUntrackedImages(ctx); err != nil {
+			u.log.WithError(err).Error("Failed to recover untracked images")
+			return
+		}
 		if err := u.MarkForResync(ctx); err != nil {
 			u.log.WithError(err).Error("Failed to mark images for resync")
 			return
@@ -211,6 +215,18 @@ func (u *Updater) MarkImagesAsUntracked(ctx context.Context) error {
 		return err
 	}
 	u.log.Debugf("MarkImagesAsUntracked affected %d rows", rowsAffected)
+	return nil
+}
+
+func (u *Updater) RecoverUntrackedImages(ctx context.Context) error {
+	rowsAffected, err := u.querier.MarkUntrackedImagesForResync(ctx)
+	if err != nil {
+		u.log.WithError(err).Error("Failed to mark untracked images for resync")
+		return err
+	}
+	if rowsAffected > 0 {
+		u.log.Infof("MarkUntrackedImagesForResync recovered %d untracked images", rowsAffected)
+	}
 	return nil
 }
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -69,7 +69,6 @@ func (u *Updater) Run(ctx context.Context) {
 		}
 		if err := u.MarkForResync(ctx); err != nil {
 			u.log.WithError(err).Error("Failed to mark images for resync")
-			return
 		}
 		if err := u.ResyncImageVulnerabilities(ctx); err != nil {
 			u.log.WithError(err).Error("Failed to resync images")

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -294,6 +294,38 @@ func TestUpdater(t *testing.T) {
 		assert.Equal(t, sql.ImageStateUntracked, image.State)
 	})
 
+	t.Run("images older than threshold without workloads should not be marked as untracked", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		// insert an image with no associated workload
+		orphanImage := "orphan-image"
+		orphanTag := "v1"
+		err = db.CreateImage(ctx, sql.CreateImageParams{
+			Name:     orphanImage,
+			Tag:      orphanTag,
+			Metadata: map[string]string{},
+		})
+		assert.NoError(t, err)
+
+		// set to initialized state, older than threshold
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state=$1, updated_at=$2 WHERE name=$3 AND tag=$4",
+			sql.ImageStateInitialized, time.Now().UTC().Add(-1*time.Hour), orphanImage, orphanTag)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.MarkImagesAsUntracked(ctx)
+		assert.NoError(t, err)
+
+		// image without a workload must NOT become untracked — MarkUnusedImages handles that
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: orphanImage, Tag: orphanTag})
+		assert.NoError(t, err)
+		assert.NotEqual(t, sql.ImageStateUntracked, image.State, "image without workload should not be marked untracked")
+		assert.Equal(t, sql.ImageStateInitialized, image.State, "image without workload should remain initialized")
+	})
+
 	t.Run("images older than threshold without workloads should be marked as unused", func(t *testing.T) {
 		err := db.ResetDatabase(ctx)
 		assert.NoError(t, err)

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -294,6 +294,38 @@ func TestUpdater(t *testing.T) {
 		assert.Equal(t, sql.ImageStateUntracked, image.State)
 	})
 
+	t.Run("image in resync state with non-null ready_for_resync_at should not be marked as untracked", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-1"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		// Simulate an image that has been through at least one resync cycle:
+		// state = resync, ready_for_resync_at is non-NULL, updated_at is old enough to pass the threshold.
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = $1, ready_for_resync_at = $2, updated_at = $3 WHERE name = $4 AND tag = $5",
+			sql.ImageStateResync,
+			time.Now().Add(-1*time.Hour), // non-NULL ready_for_resync_at
+			time.Now().Add(-1*time.Hour), // old enough to pass threshold
+			imageName, imageVersion,
+		)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.MarkImagesAsUntracked(ctx)
+		assert.NoError(t, err)
+
+		// The image must NOT be flipped to untracked because ready_for_resync_at IS NOT NULL,
+		// which indicates an active or recently-scheduled resync.
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.NotEqual(t, sql.ImageStateUntracked, image.State, "image with non-null ready_for_resync_at should not be marked untracked")
+		assert.Equal(t, sql.ImageStateResync, image.State, "image should remain in resync state")
+	})
+
 	t.Run("images older than threshold without workloads should not be marked as untracked", func(t *testing.T) {
 		err = db.ResetDatabase(ctx)
 		assert.NoError(t, err)

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -326,6 +326,56 @@ func TestUpdater(t *testing.T) {
 		assert.Equal(t, sql.ImageStateInitialized, image.State, "image without workload should remain initialized")
 	})
 
+	t.Run("untracked images with workloads should be marked for resync automatically", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-1"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = $1, ready_for_resync_at = NULL, updated_at = $2 WHERE name = $3 AND tag = $4",
+			sql.ImageStateUntracked, time.Now().Add(-1*time.Hour), imageName, imageVersion,
+		)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.RecoverUntrackedImages(ctx)
+		assert.NoError(t, err)
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateResync, image.State)
+		assert.True(t, image.ReadyForResyncAt.Valid)
+		now := time.Now()
+		assert.WithinDuration(t, now, image.ReadyForResyncAt.Time, 2*time.Second)
+	})
+
+	t.Run("untracked images without workloads should remain untracked", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-1"
+		imageVersion := "v1"
+
+		_, err = pool.Exec(ctx,
+			"INSERT INTO images (name, tag, state, updated_at) VALUES ($1, $2, $3, $4)",
+			imageName, imageVersion, sql.ImageStateUntracked, time.Now().Add(-1*time.Hour),
+		)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.RecoverUntrackedImages(ctx)
+		assert.NoError(t, err)
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateUntracked, image.State)
+	})
+
 	t.Run("images older than threshold without workloads should be marked as unused", func(t *testing.T) {
 		err := db.ResetDatabase(ctx)
 		assert.NoError(t, err)


### PR DESCRIPTION
This pull request introduces improvements to the handling and recovery of "untracked" images within the database and updater logic. The main goal is to ensure that images in the "untracked" state, which are still associated with active workloads, are automatically recovered and marked for resynchronization. The changes include new SQL queries, updates to the Go codebase to support the new recovery flow, enhancements to mock and interface definitions, and expanded integration tests to validate the new logic.

**Key changes:**

**Database and Query Logic Improvements:**
- Added a new SQL migration to create a partial index on `images.state` for efficient lookup of untracked images, improving recovery performance.
- Introduced a new SQL query and Go method (`MarkUntrackedImagesForResync`) to automatically transition "untracked" images with active workloads back to the "resync" state, setting `ready_for_resync_at` accordingly. [[1]](diffhunk://#diff-ac73cdf95f9c38f2e150cf4c7b6d698181e95587870651783f7822f010aa832aR140-R157) [[2]](diffhunk://#diff-4a8ade3b1411497ee32d54fb093571ccbefdd2e523055d340f2104cce8547fb4R214-R240)
- Updated existing queries for marking images as untracked to ensure images are only untracked if `ready_for_resync_at` is NULL and there is an associated workload, preventing premature state changes. [[1]](diffhunk://#diff-ac73cdf95f9c38f2e150cf4c7b6d698181e95587870651783f7822f010aa832aL73-R84) [[2]](diffhunk://#diff-4a8ade3b1411497ee32d54fb093571ccbefdd2e523055d340f2104cce8547fb4L162-R172)

**Updater Logic Enhancements:**
- Added a new `RecoverUntrackedImages` method to the updater, which invokes the recovery query and logs the outcome. Integrated this recovery step into the updater's scheduled run sequence. [[1]](diffhunk://#diff-07f86aa363d0be00f9de8b4134d96188f3923b9557bc3428c65c8541027ea68dR67-L69) [[2]](diffhunk://#diff-07f86aa363d0be00f9de8b4134d96188f3923b9557bc3428c65c8541027ea68dR219-R230)

**Testing and Mock Support:**
- Expanded integration tests to cover scenarios such as ensuring images with non-null `ready_for_resync_at` are not incorrectly untracked, untracked images with workloads are properly recovered, and untracked images without workloads remain unchanged.
- Added mock and interface support for the new recovery method to facilitate unit testing. [[1]](diffhunk://#diff-603c6bb43b16b3097c7f892e3dfcd94a2e05f4bfe520fdb03d406b7242ae1601R63) [[2]](diffhunk://#diff-63ec111c1e43f27acc0ce5d6f600f115793eec4a60cb96c1e10c2100bf36f2faR2848-R2903)

These changes collectively improve the robustness and correctness of image state management, especially around the recovery and resynchronization of untracked images.