### PR TITLE
refactor: replace inline upload logic

### DIFF
--- a/internal/api/grpcmgmt/server.go
+++ b/internal/api/grpcmgmt/server.go
@@ -255,11 +255,11 @@ func (s *Server) Resync(ctx context.Context, request *management.ResyncRequest) 
 				}
 			}()
 		}
+	}
 
-		if len(workloads) == 0 {
-			s.log.Debugf("no workloads to resync")
-			return &management.ResyncResponse{}, nil
-		}
+	if len(workloads) == 0 {
+		s.log.Debugf("no workloads to resync")
+		return &management.ResyncResponse{}, nil
 	}
 
 	numWorkloads, err := safeIntToInt32(len(workloads))

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -127,6 +127,7 @@ UPDATE
     images
 SET
     state = 'resync',
+    ready_for_resync_at = NOW(),
     updated_at = NOW()
 FROM
     workloads w

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -190,6 +190,7 @@ UPDATE
     images
 SET
     state = 'resync',
+    ready_for_resync_at = NOW(),
     updated_at = NOW()
 FROM
     workloads w

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -143,7 +143,12 @@ func (q *Queries) CountVulnerabilities(ctx context.Context, arg CountVulnerabili
 }
 
 const getCanonicalCveIdByAlias = `-- name: GetCanonicalCveIdByAlias :one
-SELECT canonical_cve_id FROM cve_alias WHERE alias = $1
+SELECT
+    canonical_cve_id
+FROM
+    cve_alias
+WHERE
+    alias = $1
 `
 
 func (q *Queries) GetCanonicalCveIdByAlias(ctx context.Context, alias string) (string, error) {

--- a/internal/manager/decision_tables.go
+++ b/internal/manager/decision_tables.go
@@ -27,7 +27,6 @@ func lookupDecision[T any](table map[Event]T, event Event, tableName string) (T,
 	return zero, fmt.Errorf("no %s decision defined for event %q: this is a bug", tableName, event)
 }
 
-//go:fix inline
 func ptr[T any](v T) *T {
 	return new(v)
 }

--- a/internal/manager/decision_tables.go
+++ b/internal/manager/decision_tables.go
@@ -27,8 +27,9 @@ func lookupDecision[T any](table map[Event]T, event Event, tableName string) (T,
 	return zero, fmt.Errorf("no %s decision defined for event %q: this is a bug", tableName, event)
 }
 
+//go:fix inline
 func ptr[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 const (
@@ -139,6 +140,32 @@ var sourceRefDecisions = map[Event]SourceRefDecision{
 	},
 	// No source ref at all: proceed straight to upload.
 	EventSourceRefMissing: {},
+}
+
+const (
+	// EventUploadUnrecoverable means upload failed permanently (e.g. 4xx/schema invalid).
+	EventUploadUnrecoverable Event = "upload_unrecoverable"
+	// EventUploadRecoverableError means upload failed transiently and should be retried.
+	EventUploadRecoverableError Event = "upload_recoverable_error"
+)
+
+// uploadAttestationDecisions contains terminal/retry behavior for upload errors.
+var uploadAttestationDecisions = map[Event]Decision{
+	EventUploadUnrecoverable: {
+		WorkloadState: ptr(sql.WorkloadStateUnrecoverable),
+		ImageState:    ptr(sql.ImageStateFailed),
+		JobStatus:     JobStatusUnrecoverable,
+		CancelJob:     true,
+	},
+	EventUploadRecoverableError: {},
+}
+
+// classifyUploadAttestationEvent maps UploadAttestation source errors to a domain event.
+func classifyUploadAttestationEvent(err error) Event {
+	if _, ok := errors.AsType[model.UnrecoverableError](err); ok {
+		return EventUploadUnrecoverable
+	}
+	return EventUploadRecoverableError
 }
 
 // classifySourceRefEvent turns the source-ref lookup and ProjectExists result

--- a/internal/manager/decision_tables_test.go
+++ b/internal/manager/decision_tables_test.go
@@ -226,6 +226,93 @@ func TestSourceRefDecisions_Correctness(t *testing.T) {
 	}
 }
 
+func TestClassifyUploadAttestationEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantEvt Event
+	}{
+		{
+			name:    "unrecoverable error",
+			err:     model.ToUnrecoverableError(errors.New("invalid sbom"), "upload"),
+			wantEvt: EventUploadUnrecoverable,
+		},
+		{
+			name:    "recoverable error",
+			err:     errors.New("timeout"),
+			wantEvt: EventUploadRecoverableError,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyUploadAttestationEvent(tc.err)
+			if got != tc.wantEvt {
+				t.Errorf("classifyUploadAttestationEvent() = %q, want %q", got, tc.wantEvt)
+			}
+		})
+	}
+}
+
+func TestUploadAttestationDecisions_Completeness(t *testing.T) {
+	allEvents := []Event{EventUploadUnrecoverable, EventUploadRecoverableError}
+	for _, ev := range allEvents {
+		if _, ok := uploadAttestationDecisions[ev]; !ok {
+			t.Errorf("uploadAttestationDecisions: missing entry for event %q", ev)
+		}
+	}
+}
+
+func TestUploadAttestationDecisions_Correctness(t *testing.T) {
+	unrecov := ptr(sql.WorkloadStateUnrecoverable)
+	failed := ptr(sql.ImageStateFailed)
+
+	tests := []struct {
+		event             Event
+		wantWorkloadState *sql.WorkloadState
+		wantImageState    *sql.ImageState
+		wantJobStatus     JobStatus
+		wantCancel        bool
+	}{
+		{
+			event:             EventUploadUnrecoverable,
+			wantWorkloadState: unrecov,
+			wantImageState:    failed,
+			wantJobStatus:     JobStatusUnrecoverable,
+			wantCancel:        true,
+		},
+		{
+			event:             EventUploadRecoverableError,
+			wantWorkloadState: nil,
+			wantImageState:    nil,
+			wantJobStatus:     "",
+			wantCancel:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.event), func(t *testing.T) {
+			d, ok := uploadAttestationDecisions[tc.event]
+			if !ok {
+				t.Fatalf("no decision found for event %q", tc.event)
+			}
+
+			if !workloadStateEqual(d.WorkloadState, tc.wantWorkloadState) {
+				t.Errorf("WorkloadState = %v, want %v", derefWS(d.WorkloadState), derefWS(tc.wantWorkloadState))
+			}
+			if !imageStateEqual(d.ImageState, tc.wantImageState) {
+				t.Errorf("ImageState = %v, want %v", derefIS(d.ImageState), derefIS(tc.wantImageState))
+			}
+			if d.JobStatus != tc.wantJobStatus {
+				t.Errorf("JobStatus = %q, want %q", d.JobStatus, tc.wantJobStatus)
+			}
+			if d.CancelJob != tc.wantCancel {
+				t.Errorf("CancelJob = %v, want %v", d.CancelJob, tc.wantCancel)
+			}
+		})
+	}
+}
+
 func TestClassifyFinalizeEvent(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/manager/upload_attestation.go
+++ b/internal/manager/upload_attestation.go
@@ -128,7 +128,62 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 	if upErr != nil {
 		span.RecordError(upErr)
 		span.SetStatus(codes.Error, "failed to upload attestation to source")
-		return handleJobErr(upErr)
+
+		event := classifyUploadAttestationEvent(upErr)
+		decision, lookupErr := lookupDecision(uploadAttestationDecisions, event, "upload_attestation")
+		if lookupErr != nil {
+			return river.JobCancel(lookupErr)
+		}
+
+		dbCtx, cancel := context.WithTimeout(ctx, attestationDBTimeout)
+		defer cancel()
+
+		if decision.WorkloadState != nil {
+			if dbErr := u.db.UpdateWorkloadState(dbCtx, sql.UpdateWorkloadStateParams{
+				State: *decision.WorkloadState,
+				ID:    job.Args.WorkloadId,
+			}); dbErr != nil {
+				return fmt.Errorf("failed to set workload state: %w", dbErr)
+			}
+		}
+
+		if decision.ImageState != nil {
+			if dbErr := u.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
+				State: *decision.ImageState,
+				Name:  imageName,
+				Tag:   imageTag,
+			}); dbErr != nil {
+				return fmt.Errorf("failed to set image state: %w", dbErr)
+			}
+		}
+
+		if decision.JobStatus != "" {
+			retry := !decision.CancelJob
+			recordStructuredOutput(ctx, JobOutput{
+				Status:    decision.JobStatus,
+				Event:     string(event),
+				Decision:  describeUploadAttestationDecision(decision),
+				Retryable: &retry,
+				Details: map[string]string{
+					"image":         imageName,
+					"tag":           imageTag,
+					"error_type":    fmt.Sprintf("%T", upErr),
+					"unrecoverable": fmt.Sprint(decision.CancelJob),
+				},
+			})
+		}
+
+		if decision.CancelJob {
+			u.log.WithError(upErr).WithFields(logrus.Fields{
+				"image": imageName,
+				"tag":   imageTag,
+			}).Warn("upload attestation failed with unrecoverable error; marked workload/image as terminal")
+		}
+
+		if decision.CancelJob {
+			return river.JobCancel(upErr)
+		}
+		return upErr
 	}
 
 	// 5. Persist upload results.
@@ -169,6 +224,16 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 		},
 	})
 	return nil
+}
+
+func describeUploadAttestationDecision(d Decision) string {
+	if d.CancelJob {
+		return "mark_failed_and_cancel"
+	}
+	if d.WorkloadState != nil || d.ImageState != nil {
+		return "update_state"
+	}
+	return "retry"
 }
 
 // checkSourceRef looks up an existing source ref for the image and checks whether

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -499,12 +499,12 @@ func TestUpdater(t *testing.T) {
 		assert.Equal(t, sql.ImageStateResync, image.State)
 		// ready_for_resync_at must be set so GetImagesScheduledForSync can pick it up
 		assert.True(t, image.ReadyForResyncAt.Valid, "ready_for_resync_at should be set by MarkForResync")
-		assert.False(t, image.ReadyForResyncAt.Time.After(time.Now()), "ready_for_resync_at should not be in the future")
 
 		scheduled, err := db.GetImagesScheduledForSync(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, scheduled, 1, "image should be immediately visible to GetImagesScheduledForSync after MarkForResync")
 		assert.Equal(t, imageName, scheduled[0].Name)
+		assert.Equal(t, imageVersion, scheduled[0].Tag)
 	})
 
 	t.Run("images marked for resync by MarkForResync should not be flipped to untracked", func(t *testing.T) {
@@ -601,7 +601,9 @@ func TestUpdater(t *testing.T) {
 		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageTag})
 		assert.NoError(t, err)
 		assert.Equal(t, sql.ImageStateResync, image.State)
-		assert.True(t, image.ReadyForResyncAt.Time.Before(time.Now()))
+		assert.True(t, image.ReadyForResyncAt.Valid, "ready_for_resync_at should be set")
+		assert.WithinDuration(t, readyAt, image.ReadyForResyncAt.Time, 2*time.Second,
+			"ready_for_resync_at should match the value we set")
 
 		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, nil, logrus.NewEntry(logrus.StandardLogger()))
 

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -497,6 +497,77 @@ func TestUpdater(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, sql.ImageStateResync, image.State)
+		// ready_for_resync_at must be set so GetImagesScheduledForSync can pick it up
+		assert.True(t, image.ReadyForResyncAt.Valid, "ready_for_resync_at should be set by MarkForResync")
+		assert.False(t, image.ReadyForResyncAt.Time.After(time.Now()), "ready_for_resync_at should not be in the future")
+
+		scheduled, err := db.GetImagesScheduledForSync(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, scheduled, 1, "image should be immediately visible to GetImagesScheduledForSync after MarkForResync")
+		assert.Equal(t, imageName, scheduled[0].Name)
+	})
+
+	t.Run("images marked for resync by MarkForResync should not be flipped to untracked", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-1"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		// Set image to updated state, old enough to be picked up by MarkForResync.
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = $1, updated_at = $2 WHERE name = $3 AND tag = $4",
+			sql.ImageStateUpdated,
+			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
+			imageName, imageVersion)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.MarkForResync(ctx)
+		assert.NoError(t, err)
+
+		// Immediately run MarkImagesAsUntracked — the image must NOT be flipped to untracked
+		// because MarkForResync now sets ready_for_resync_at, which acts as the protection guard.
+		err = u.MarkImagesAsUntracked(ctx)
+		assert.NoError(t, err)
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateResync, image.State,
+			"image queued by MarkForResync must not be flipped to untracked by MarkImagesAsUntracked")
+	})
+
+	t.Run("MarkForResync does not reset ready_for_resync_at of an image already in resync state", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-1"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		// Image already in resync with a future ready_for_resync_at.
+		futureResync := time.Now().Add(5 * time.Minute)
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = $1, ready_for_resync_at = $2, updated_at = $3 WHERE name = $4 AND tag = $5",
+			sql.ImageStateResync,
+			futureResync,
+			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
+			imageName, imageVersion)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()))
+
+		err = u.MarkForResync(ctx)
+		assert.NoError(t, err)
+
+		// The image was already in resync — MarkForResync excludes state='resync', so it must be untouched.
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateResync, image.State)
+		assert.WithinDuration(t, futureResync, image.ReadyForResyncAt.Time, time.Second,
+			"ready_for_resync_at of an already-resync image must not be overwritten by MarkForResync")
 	})
 
 	t.Run("images ready for resync after SBOM upload", func(t *testing.T) {


### PR DESCRIPTION
Improved error handling and state management for upload attestation failures, as well as enhancements to the image resync process. The main changes include new logic to classify upload errors, update workload and image states accordingly, and ensure images marked for resync are properly tracked and tested.

**Upload attestation error handling and state management:**

* Added new event types (`EventUploadUnrecoverable`, `EventUploadRecoverableError`) and a decision table (`uploadAttestationDecisions`) to control behavior when upload attestation fails, including whether to retry, mark as failed, or cancel jobs. Also introduced logic to classify errors and update database states based on the decision. [[1]](diffhunk://#diff-a64bab8ca09aedade91a655f1f1efac70d00b1ea7bcfeb6f8e0c3d9bbbea4f64R145-R170) [[2]](diffhunk://#diff-8730f3eda07f06374f12eba221cbccfb9b7cc98798389c1c402df5f194747f2bL131-R186) [[3]](diffhunk://#diff-8730f3eda07f06374f12eba221cbccfb9b7cc98798389c1c402df5f194747f2bR229-R238)
* Updated the `ptr` helper function to use `new(v)` for pointer creation, improving type safety.

**Testing and correctness:**

* Added comprehensive unit tests for upload attestation event classification and decision table completeness/correctness, ensuring robust error handling logic.

**Minor fixes:**

* Reformatted a SQL query for clarity in the vulnerabilities code.
* Fixed a misplaced closing brace in `Resync` server logic for improved code clarity.