### PR TITLE
feat: river job error handling

### DIFF
--- a/internal/api/grpcmgmt/server.go
+++ b/internal/api/grpcmgmt/server.go
@@ -235,7 +235,7 @@ func (s *Server) Resync(ctx context.Context, request *management.ResyncRequest) 
 			fmt.Sprintf("%s/%s/%s/%s", workload.Cluster, workload.Namespace, workload.Type, workload.Name))
 
 		if request.ImageState != nil {
-			err = s.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			_, err = s.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
 				State: sql.ImageState(*request.ImageState),
 				Name:  workload.ImageName,
 				Tag:   workload.ImageTag,

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -582,7 +582,7 @@ func (s *Server) SuppressVulnerability(ctx context.Context, request *vulnerabili
 		return nil, fmt.Errorf("recalculate vulnerability summary: %w", err)
 	}
 
-	err = s.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+	_, err = s.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
 		State: sql.ImageStateResync,
 		Name:  vuln.ImageName,
 		Tag:   vuln.ImageTag,

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -58,7 +58,7 @@ func TestMarkImagesAsUnused(t *testing.T) {
 		})
 		assert.NoError(t, err)
 
-		err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  image.Name,
 			Tag:   image.Tag,
 			State: sql.ImageStateResync,

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -42,7 +42,7 @@ WHERE
 ORDER BY
     updated_at DESC;
 
--- name: UpdateImageState :exec
+-- name: UpdateImageState :execrows
 UPDATE
     images
 SET

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -294,7 +294,7 @@ func (q *Queries) UpdateImage(ctx context.Context, arg UpdateImageParams) error 
 	return err
 }
 
-const updateImageState = `-- name: UpdateImageState :exec
+const updateImageState = `-- name: UpdateImageState :execrows
 UPDATE
     images
 SET
@@ -313,14 +313,17 @@ type UpdateImageStateParams struct {
 	Tag              string
 }
 
-func (q *Queries) UpdateImageState(ctx context.Context, arg UpdateImageStateParams) error {
-	_, err := q.db.Exec(ctx, updateImageState,
+func (q *Queries) UpdateImageState(ctx context.Context, arg UpdateImageStateParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateImageState,
 		arg.State,
 		arg.ReadyForResyncAt,
 		arg.Name,
 		arg.Tag,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateImageSyncStatus = `-- name: UpdateImageSyncStatus :exec

--- a/internal/database/sql/querier.go
+++ b/internal/database/sql/querier.go
@@ -69,7 +69,7 @@ type Querier interface {
 	SetWorkloadState(ctx context.Context, arg SetWorkloadStateParams) ([]*SetWorkloadStateRow, error)
 	SuppressVulnerability(ctx context.Context, arg SuppressVulnerabilityParams) error
 	UpdateImage(ctx context.Context, arg UpdateImageParams) error
-	UpdateImageState(ctx context.Context, arg UpdateImageStateParams) error
+	UpdateImageState(ctx context.Context, arg UpdateImageStateParams) (int64, error)
 	UpdateImageSyncStatus(ctx context.Context, arg UpdateImageSyncStatusParams) error
 	UpdateWorkloadState(ctx context.Context, arg UpdateWorkloadStateParams) error
 	UpsertVulnerabilityLifetimes(ctx context.Context) error

--- a/internal/job/client.go
+++ b/internal/job/client.go
@@ -66,11 +66,14 @@ func NewClient(ctx context.Context, cfg *Config, queues map[string]river.QueueCo
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	workers := river.NewWorkers()
 	riverClient, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
-		Logger: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		})),
+		ErrorHandler:         newAttestationErrorHandler(pool, logger),
+		Logger:               logger,
 		Queues:               queues,
 		Workers:              workers,
 		JobTimeout:           5 * time.Minute,

--- a/internal/job/error_handler.go
+++ b/internal/job/error_handler.go
@@ -1,0 +1,74 @@
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/nais/v13s/internal/database/sql"
+	"github.com/nais/v13s/internal/model"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+type attestationErrorHandler struct {
+	db  sql.Querier
+	log *slog.Logger
+}
+
+func newAttestationErrorHandler(pool *pgxpool.Pool, log *slog.Logger) river.ErrorHandler {
+	return &attestationErrorHandler{
+		db:  sql.New(pool),
+		log: log,
+	}
+}
+
+// HandleError is called by River on every failed job attempt. When a
+// get_attestation job has exhausted all attempts (i.e. is about to be
+// discarded), the image is marked as failed so it does not remain stuck in
+// resync indefinitely.
+func (h *attestationErrorHandler) HandleError(ctx context.Context, job *rivertype.JobRow, err error) *river.ErrorHandlerResult {
+	if job.Kind == model.JobKindGetAttestation && job.Attempt >= job.MaxAttempts {
+		h.markImageFailed(ctx, job)
+	}
+	return nil
+}
+
+// HandlePanic is called by River when a job panics. Same discard logic as
+// HandleError applies.
+func (h *attestationErrorHandler) HandlePanic(ctx context.Context, job *rivertype.JobRow, panicVal any, trace string) *river.ErrorHandlerResult {
+	if job.Kind == model.JobKindGetAttestation && job.Attempt >= job.MaxAttempts {
+		h.markImageFailed(ctx, job)
+	}
+	return nil
+}
+
+func (h *attestationErrorHandler) markImageFailed(ctx context.Context, job *rivertype.JobRow) {
+	var args struct {
+		ImageName string `json:"ImageName"`
+		ImageTag  string `json:"ImageTag"`
+	}
+	if err := json.Unmarshal(job.EncodedArgs, &args); err != nil {
+		h.log.Error("error_handler: failed to decode get_attestation args", "job_id", job.ID, "err", err)
+		return
+	}
+	if err := h.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		State: sql.ImageStateFailed,
+		Name:  args.ImageName,
+		Tag:   args.ImageTag,
+	}); err != nil {
+		h.log.Error("error_handler: failed to mark image as failed after get_attestation exhausted all attempts",
+			"job_id", job.ID,
+			"image", args.ImageName,
+			"tag", args.ImageTag,
+			"err", err,
+		)
+	} else {
+		h.log.Info("error_handler: marked image as failed after get_attestation exhausted all attempts",
+			"job_id", job.ID,
+			"image", args.ImageName,
+			"tag", args.ImageTag,
+		)
+	}
+}

--- a/internal/job/error_handler.go
+++ b/internal/job/error_handler.go
@@ -53,16 +53,23 @@ func (h *attestationErrorHandler) markImageFailed(ctx context.Context, job *rive
 		h.log.Error("error_handler: failed to decode get_attestation args", "job_id", job.ID, "err", err)
 		return
 	}
-	if err := h.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+	n, err := h.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 		State: sql.ImageStateFailed,
 		Name:  args.ImageName,
 		Tag:   args.ImageTag,
-	}); err != nil {
+	})
+	if err != nil {
 		h.log.Error("error_handler: failed to mark image as failed after get_attestation exhausted all attempts",
 			"job_id", job.ID,
 			"image", args.ImageName,
 			"tag", args.ImageTag,
 			"err", err,
+		)
+	} else if n == 0 {
+		h.log.Warn("error_handler: UpdateImageState matched no rows, image may already be gone",
+			"job_id", job.ID,
+			"image", args.ImageName,
+			"tag", args.ImageTag,
 		)
 	} else {
 		h.log.Info("error_handler: marked image as failed after get_attestation exhausted all attempts",

--- a/internal/job/error_handler.go
+++ b/internal/job/error_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nais/v13s/internal/database/sql"
@@ -11,6 +12,8 @@ import (
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 )
+
+const errorHandlerDBTimeout = 5 * time.Second
 
 type attestationErrorHandler struct {
 	db  sql.Querier
@@ -53,7 +56,11 @@ func (h *attestationErrorHandler) markImageFailed(ctx context.Context, job *rive
 		h.log.Error("error_handler: failed to decode get_attestation args", "job_id", job.ID, "err", err)
 		return
 	}
-	n, err := h.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+
+	dbCtx, cancel := context.WithTimeout(ctx, errorHandlerDBTimeout)
+	defer cancel()
+
+	n, err := h.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
 		State: sql.ImageStateFailed,
 		Name:  args.ImageName,
 		Tag:   args.ImageTag,

--- a/internal/job/error_handler_test.go
+++ b/internal/job/error_handler_test.go
@@ -1,0 +1,123 @@
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/nais/v13s/internal/database/sql"
+	mockquerier "github.com/nais/v13s/internal/mocks/Querier"
+	"github.com/nais/v13s/internal/model"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/mock"
+)
+
+func encodeGetAttestationArgs(t *testing.T, imageName, imageTag string) []byte {
+	t.Helper()
+	b, err := json.Marshal(struct {
+		ImageName string `json:"ImageName"`
+		ImageTag  string `json:"ImageTag"`
+	}{ImageName: imageName, ImageTag: imageTag})
+	if err != nil {
+		t.Fatalf("failed to encode args: %v", err)
+	}
+	return b
+}
+
+func TestAttestationErrorHandler_HandleError(t *testing.T) {
+	t.Run("marks image failed on final attempt", func(t *testing.T) {
+		querier := mockquerier.NewMockQuerier(t)
+		querier.On("UpdateImageState", mock.Anything, sql.UpdateImageStateParams{
+			State: sql.ImageStateFailed,
+			Name:  "docker.io/devopsfaith/krakend",
+			Tag:   "2.5.1",
+		}).Return(nil).Once()
+
+		h := &attestationErrorHandler{db: querier, log: slog.Default()}
+
+		job := &rivertype.JobRow{
+			Kind:        model.JobKindGetAttestation,
+			Attempt:     4,
+			MaxAttempts: 4,
+			EncodedArgs: encodeGetAttestationArgs(t, "docker.io/devopsfaith/krakend", "2.5.1"),
+		}
+
+		result := h.HandleError(context.Background(), job, errors.New("i/o timeout"))
+
+		if result != nil {
+			t.Errorf("expected nil ErrorHandlerResult, got %+v", result)
+		}
+		querier.AssertExpectations(t)
+	})
+
+	t.Run("does not update state on non-final attempt", func(t *testing.T) {
+		querier := mockquerier.NewMockQuerier(t)
+		// UpdateImageState should NOT be called
+
+		h := &attestationErrorHandler{db: querier, log: slog.Default()}
+
+		job := &rivertype.JobRow{
+			Kind:        model.JobKindGetAttestation,
+			Attempt:     2,
+			MaxAttempts: 4,
+			EncodedArgs: encodeGetAttestationArgs(t, "docker.io/devopsfaith/krakend", "2.5.1"),
+		}
+
+		result := h.HandleError(context.Background(), job, errors.New("i/o timeout"))
+
+		if result != nil {
+			t.Errorf("expected nil ErrorHandlerResult, got %+v", result)
+		}
+		querier.AssertNotCalled(t, "UpdateImageState")
+	})
+
+	t.Run("ignores non-get_attestation jobs on final attempt", func(t *testing.T) {
+		querier := mockquerier.NewMockQuerier(t)
+		// UpdateImageState should NOT be called
+
+		h := &attestationErrorHandler{db: querier, log: slog.Default()}
+
+		job := &rivertype.JobRow{
+			Kind:        "upload_attestation",
+			Attempt:     4,
+			MaxAttempts: 4,
+			EncodedArgs: []byte(`{}`),
+		}
+
+		result := h.HandleError(context.Background(), job, errors.New("some error"))
+
+		if result != nil {
+			t.Errorf("expected nil ErrorHandlerResult, got %+v", result)
+		}
+		querier.AssertNotCalled(t, "UpdateImageState")
+	})
+}
+
+func TestAttestationErrorHandler_HandlePanic(t *testing.T) {
+	t.Run("marks image failed on final attempt panic", func(t *testing.T) {
+		querier := mockquerier.NewMockQuerier(t)
+		querier.On("UpdateImageState", mock.Anything, sql.UpdateImageStateParams{
+			State: sql.ImageStateFailed,
+			Name:  "docker.io/devopsfaith/krakend",
+			Tag:   "2.5.1",
+		}).Return(nil).Once()
+
+		h := &attestationErrorHandler{db: querier, log: slog.Default()}
+
+		job := &rivertype.JobRow{
+			Kind:        model.JobKindGetAttestation,
+			Attempt:     4,
+			MaxAttempts: 4,
+			EncodedArgs: encodeGetAttestationArgs(t, "docker.io/devopsfaith/krakend", "2.5.1"),
+		}
+
+		result := h.HandlePanic(context.Background(), job, "something panicked", "stack trace")
+
+		if result != nil {
+			t.Errorf("expected nil ErrorHandlerResult, got %+v", result)
+		}
+		querier.AssertExpectations(t)
+	})
+}

--- a/internal/job/error_handler_test.go
+++ b/internal/job/error_handler_test.go
@@ -33,7 +33,7 @@ func TestAttestationErrorHandler_HandleError(t *testing.T) {
 			State: sql.ImageStateFailed,
 			Name:  "docker.io/devopsfaith/krakend",
 			Tag:   "2.5.1",
-		}).Return(nil).Once()
+		}).Return(int64(1), nil).Once()
 
 		h := &attestationErrorHandler{db: querier, log: slog.Default()}
 
@@ -102,7 +102,7 @@ func TestAttestationErrorHandler_HandlePanic(t *testing.T) {
 			State: sql.ImageStateFailed,
 			Name:  "docker.io/devopsfaith/krakend",
 			Tag:   "2.5.1",
-		}).Return(nil).Once()
+		}).Return(int64(1), nil).Once()
 
 		h := &attestationErrorHandler{db: querier, log: slog.Default()}
 

--- a/internal/manager/finalize_attestation.go
+++ b/internal/manager/finalize_attestation.go
@@ -93,7 +93,7 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 
 	// 4. Mark image as ready for resync.
 	if decision.MarkResync {
-		if err := f.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		n, err := f.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  imageName,
 			Tag:   imageTag,
 			State: sql.ImageStateResync,
@@ -101,8 +101,12 @@ func (f *FinalizeAttestationWorker) Work(ctx context.Context, job *river.Job[Fin
 				Time:  time.Now().Add(FinalizeAttestationResync),
 				Valid: true,
 			},
-		}); err != nil {
+		})
+		if err != nil {
 			return fmt.Errorf("failed to update image state: %w", err)
+		}
+		if n == 0 {
+			f.log.WithFields(logrus.Fields{"image": imageName, "tag": imageTag}).Warn("UpdateImageState matched no rows, image may already be gone")
 		}
 	}
 

--- a/internal/manager/get_attestation.go
+++ b/internal/manager/get_attestation.go
@@ -114,12 +114,16 @@ func (g *GetAttestationWorker) Work(ctx context.Context, job *river.Job[GetAttes
 	}
 
 	if decision.ImageState != nil {
-		if dbErr := g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
+		n, dbErr := g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
 			State: *decision.ImageState,
 			Name:  imageName,
 			Tag:   imageTag,
-		}); dbErr != nil {
+		})
+		if dbErr != nil {
 			return fmt.Errorf("failed to set image state: %w", dbErr)
+		}
+		if n == 0 {
+			g.log.WithFields(logFields).Warn("UpdateImageState matched no rows, image may already be gone")
 		}
 	}
 

--- a/internal/manager/get_attestation.go
+++ b/internal/manager/get_attestation.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	KindGetAttestation   = "get_attestation"
 	attestationDBTimeout = 10 * time.Second
 )
 
@@ -30,11 +29,11 @@ type GetAttestationJob struct {
 	WorkloadType model.WorkloadType
 }
 
-func (GetAttestationJob) Kind() string { return KindGetAttestation }
+func (GetAttestationJob) Kind() string { return model.JobKindGetAttestation }
 
 func (g GetAttestationJob) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{
-		Queue: KindGetAttestation,
+		Queue: model.JobKindGetAttestation,
 		UniqueOpts: river.UniqueOpts{
 			ByArgs:   true,
 			ByPeriod: 1 * time.Minute,

--- a/internal/manager/upload_attestation.go
+++ b/internal/manager/upload_attestation.go
@@ -93,7 +93,7 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 	}
 
 	if sourceRefDecision.ResyncAndReturn {
-		if err := u.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		n, err := u.db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  imageName,
 			Tag:   imageTag,
 			State: sql.ImageStateResync,
@@ -101,8 +101,12 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 				Time:  time.Now(),
 				Valid: true,
 			},
-		}); err != nil {
+		})
+		if err != nil {
 			return fmt.Errorf("failed to update image state: %w", err)
+		}
+		if n == 0 {
+			u.log.WithFields(logrus.Fields{"image": imageName, "tag": imageTag}).Warn("UpdateImageState matched no rows, image may already be gone")
 		}
 		recordStructuredOutput(ctx, JobOutput{
 			Status:   sourceRefDecision.JobStatus,
@@ -148,12 +152,16 @@ func (u *UploadAttestationWorker) Work(ctx context.Context, job *river.Job[Uploa
 		}
 
 		if decision.ImageState != nil {
-			if dbErr := u.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
+			n, dbErr := u.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
 				State: *decision.ImageState,
 				Name:  imageName,
 				Tag:   imageTag,
-			}); dbErr != nil {
+			})
+			if dbErr != nil {
 				return fmt.Errorf("failed to set image state: %w", dbErr)
+			}
+			if n == 0 {
+				u.log.WithFields(logrus.Fields{"image": imageName, "tag": imageTag}).Warn("UpdateImageState matched no rows, image may already be gone")
 			}
 		}
 

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -53,12 +53,12 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 	db := sql.New(pool)
 
 	queues := map[string]river.QueueConfig{
-		KindAddWorkload:         {MaxWorkers: 8},
-		KindGetAttestation:      {MaxWorkers: 25},
-		KindUploadAttestation:   {MaxWorkers: 5},
-		KindDeleteWorkload:      {MaxWorkers: 3},
-		KindRemoveFromSource:    {MaxWorkers: 3},
-		KindFinalizeAttestation: {MaxWorkers: 10},
+		KindAddWorkload:             {MaxWorkers: 8},
+		model.JobKindGetAttestation: {MaxWorkers: 25},
+		KindUploadAttestation:       {MaxWorkers: 5},
+		KindDeleteWorkload:          {MaxWorkers: 3},
+		KindRemoveFromSource:        {MaxWorkers: 3},
+		KindFinalizeAttestation:     {MaxWorkers: 10},
 	}
 
 	jobClient, err := job.NewClient(ctx, jobCfg, queues)
@@ -66,7 +66,7 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 		log.Fatalf("Failed to create job client: %v", err)
 	}
 	job.AddWorker(jobClient, &AddWorkloadWorker{db: db, jobClient: jobClient, log: log.WithField("subsystem", "add_workload")})
-	job.AddWorker(jobClient, &GetAttestationWorker{db: db, verifier: verifier, jobClient: jobClient, workloadCounter: udCounter, log: log.WithField("subsystem", "get_attestation")})
+	job.AddWorker(jobClient, &GetAttestationWorker{db: db, verifier: verifier, jobClient: jobClient, workloadCounter: udCounter, log: log.WithField("subsystem", model.JobKindGetAttestation)})
 	job.AddWorker(jobClient, &UploadAttestationWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "upload_attestation")})
 	job.AddWorker(jobClient, &RemoveFromSourceWorker{db: db, source: source, log: log.WithField("subsystem", "remove_from_source")})
 	job.AddWorker(jobClient, &DeleteWorkloadWorker{db: db, jobClient: jobClient, log: log.WithField("subsystem", "delete_workload")})
@@ -127,55 +127,6 @@ func (m *WorkloadManager) DeleteWorkload(ctx context.Context, workload *model.Wo
 func (m *WorkloadManager) AddJob(ctx context.Context, job river.JobArgs) error {
 	return m.jobClient.AddJob(ctx, job)
 }
-
-/*func (m *WorkloadManager) handleError(ctx context.Context, workload *model.Workload, originalErr error) {
-	m.Log.WithField("workload", workload.String()).WithError(originalErr).Error("processing workload")
-	state := sql.WorkloadStateFailed
-	subsystem := WorkloadEventSubsystemUnknown
-	eventType := WorkloadEventFailed
-
-	var uErr model.UnrecoverableError
-	if errors.As(originalErr, &uErr) {
-		m.Log.WithField("workload", workload.String()).Error("unrecoverable error, marking workload as unrecoverable")
-		subsystem = uErr.Subsystem
-		state = sql.WorkloadStateUnrecoverable
-		eventType = WorkloadEventUnrecoverable
-	}
-
-	var rErr model.RecoverableError
-	if errors.As(originalErr, &rErr) {
-		m.Log.WithField("workload", workload.String()).Error("recoverable error, marking workload as failed")
-		subsystem = rErr.Subsystem
-		state = sql.WorkloadStateFailed
-		eventType = WorkloadEventRecoverable
-	}
-
-	err := m.Db.AddWorkloadEvent(ctx, sql.AddWorkloadEventParams{
-		Name:         workload.Name,
-		Cluster:      workload.Cluster,
-		Namespace:    workload.Namespace,
-		WorkloadType: string(workload.Type),
-		EventType:    string(eventType),
-		EventData:    originalErr.Error(),
-		Subsystem:    subsystem,
-	})
-	if err != nil {
-		m.Log.WithError(err).WithField("workload", workload).Error("failed to add workload event")
-	}
-
-	err = m.Db.SetWorkloadState(ctx, sql.SetWorkloadStateParams{
-		Name:         workload.Name,
-		Cluster:      workload.Cluster,
-		Namespace:    workload.Namespace,
-		WorkloadType: string(workload.Type),
-		ImageName:    workload.ImageName,
-		ImageTag:     workload.ImageTag,
-		State:        state,
-	})
-	if err != nil {
-		m.Log.WithError(err).WithField("workload", workload).Error("failed to set workload state")
-	}
-}*/
 
 func (m *WorkloadManager) Stop(ctx context.Context) error {
 	return m.jobClient.Stop(ctx)

--- a/internal/mocks/Querier/mock_querier.go
+++ b/internal/mocks/Querier/mock_querier.go
@@ -3298,21 +3298,31 @@ func (_c *MockQuerier_UpdateImage_Call) RunAndReturn(run func(context.Context, s
 }
 
 // UpdateImageState provides a mock function with given fields: ctx, arg
-func (_m *MockQuerier) UpdateImageState(ctx context.Context, arg sql.UpdateImageStateParams) error {
+func (_m *MockQuerier) UpdateImageState(ctx context.Context, arg sql.UpdateImageStateParams) (int64, error) {
 	ret := _m.Called(ctx, arg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateImageState")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, sql.UpdateImageStateParams) error); ok {
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, sql.UpdateImageStateParams) (int64, error)); ok {
+		return rf(ctx, arg)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, sql.UpdateImageStateParams) int64); ok {
 		r0 = rf(ctx, arg)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(int64)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, sql.UpdateImageStateParams) error); ok {
+		r1 = rf(ctx, arg)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockQuerier_UpdateImageState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateImageState'
@@ -3334,12 +3344,12 @@ func (_c *MockQuerier_UpdateImageState_Call) Run(run func(ctx context.Context, a
 	return _c
 }
 
-func (_c *MockQuerier_UpdateImageState_Call) Return(_a0 error) *MockQuerier_UpdateImageState_Call {
-	_c.Call.Return(_a0)
+func (_c *MockQuerier_UpdateImageState_Call) Return(_a0 int64, _a1 error) *MockQuerier_UpdateImageState_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockQuerier_UpdateImageState_Call) RunAndReturn(run func(context.Context, sql.UpdateImageStateParams) error) *MockQuerier_UpdateImageState_Call {
+func (_c *MockQuerier_UpdateImageState_Call) RunAndReturn(run func(context.Context, sql.UpdateImageStateParams) (int64, error)) *MockQuerier_UpdateImageState_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -1,0 +1,6 @@
+package model
+
+// JobKindGetAttestation Job kind constants for River job types.
+const (
+	JobKindGetAttestation = "get_attestation"
+)

--- a/internal/model/job.go
+++ b/internal/model/job.go
@@ -1,6 +1,6 @@
 package model
 
-// JobKindGetAttestation Job kind constants for River job types.
+// JobKindGetAttestation is the job kind for get attestation jobs.
 const (
 	JobKindGetAttestation = "get_attestation"
 )

--- a/internal/updater/db.go
+++ b/internal/updater/db.go
@@ -38,7 +38,7 @@ func SyncImage(ctx context.Context, imageName, imageTag, source string, f func(c
 	if err != nil {
 		err = handleError(ctx, imageName, imageTag, source, err)
 		if err != nil {
-			err = d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			n, err := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
 				Name:  imageName,
 				Tag:   imageTag,
 				State: sql.ImageStateFailed,
@@ -46,6 +46,9 @@ func SyncImage(ctx context.Context, imageName, imageTag, source string, f func(c
 			if err != nil {
 				d.log.Errorf("failed to update image state: %v", err)
 				return fmt.Errorf("updating image state: %w", err)
+			}
+			if n == 0 {
+				d.log.Warnf("UpdateImageState matched no rows for image %s:%s, image may already be gone", imageName, imageTag)
 			}
 			return nil
 		}

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -587,7 +587,7 @@ func TestUpdater(t *testing.T) {
 		assert.NoError(t, err)
 
 		readyAt := time.Now().Add(-manager.FinalizeAttestationResync)
-		err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			Name:  imageName,
 			Tag:   imageTag,
 			State: sql.ImageStateResync,


### PR DESCRIPTION
This pull request refactors the `UpdateImageState` database operation to return the number of affected rows, enabling improved error handling and logging throughout the codebase. It also introduces a custom River job error handler to mark images as failed if attestation jobs exhaust all attempts, and adds thorough unit tests for this logic. Additionally, it standardizes job kind naming and improves logging when image state updates have no effect.

**Database API changes:**

* The `UpdateImageState` method now returns `(int64, error)` representing the number of affected rows, instead of just `error`. This change is reflected in the SQL query annotation (`:execrows`) and all interface/mocking code. [[1]](diffhunk://#diff-ac73cdf95f9c38f2e150cf4c7b6d698181e95587870651783f7822f010aa832aL45-R45) [[2]](diffhunk://#diff-4a8ade3b1411497ee32d54fb093571ccbefdd2e523055d340f2104cce8547fb4L297-R297) [[3]](diffhunk://#diff-4a8ade3b1411497ee32d54fb093571ccbefdd2e523055d340f2104cce8547fb4L316-R326) [[4]](diffhunk://#diff-603c6bb43b16b3097c7f892e3dfcd94a2e05f4bfe520fdb03d406b7242ae1601L72-R72) [[5]](diffhunk://#diff-63ec111c1e43f27acc0ce5d6f600f115793eec4a60cb96c1e10c2100bf36f2faL3301-R3325) [[6]](diffhunk://#diff-63ec111c1e43f27acc0ce5d6f600f115793eec4a60cb96c1e10c2100bf36f2faL3337-R3352)

**Error handling improvements:**

* Introduced an `attestationErrorHandler` for River jobs, which marks images as failed in the database if a `get_attestation` job exhausts all attempts, preventing images from being stuck in the resync state. [[1]](diffhunk://#diff-094fea464513cc211ac0c045de27227db7d250b4ca7a0ecbedb2c5ac500afc28R1-R88) [[2]](diffhunk://#diff-929cfc687cf97c140a0ef21157663c72098e4b68b91a68071de4cc6dda1f3093R69-R76)

**Logging and observability:**

* All call sites to `UpdateImageState` now check if zero rows are affected and log a warning if so, improving visibility into potential race conditions or deleted images. [[1]](diffhunk://#diff-4beb45dc98b47ffa6bdf2c728de6120d5a884a7e539b2ab96e13d7a2dcfb910bL96-R110) [[2]](diffhunk://#diff-ae79af46bb3e69eba18f908ffa951be14d1bfe1174e2264429fd5ac3658c2707L118-R127) [[3]](diffhunk://#diff-8730f3eda07f06374f12eba221cbccfb9b7cc98798389c1c402df5f194747f2bL96-R110) [[4]](diffhunk://#diff-8730f3eda07f06374f12eba221cbccfb9b7cc98798389c1c402df5f194747f2bL151-R165)

**Testing:**

* Added unit tests for the new error handler, covering both error and panic cases, and verifying correct database interactions.

**Job kind naming consistency:**

* Replaced direct references to the `KindGetAttestation` constant with `model.JobKindGetAttestation` throughout the codebase for consistency. [[1]](diffhunk://#diff-ae79af46bb3e69eba18f908ffa951be14d1bfe1174e2264429fd5ac3658c2707L22) [[2]](diffhunk://#diff-ae79af46bb3e69eba18f908ffa951be14d1bfe1174e2264429fd5ac3658c2707L33-R36) [[3]](diffhunk://#diff-a8874601b8a1ea94eb08b71d2d89d3026b5014cb6375e6debf8056d7babd9a0fL57-R57) [[4]](diffhunk://#diff-a8874601b8a1ea94eb08b71d2d89d3026b5014cb6375e6debf8056d7babd9a0fL69-R69)