### PR TITLE
ci: rename rollout job to deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
         run: |-
           helm push ${{ env.NAME }}*.tgz ${{ env.FEATURE_REPOSITORY }}
 
-  rollout:
+  deploy:
     if: github.ref == 'refs/heads/main'
     needs:
       - build_and_push


### PR DESCRIPTION
Align job naming with the new deployment-konsept (fasit-deploy v4). Pure rename, no behavioral change.