### PR TITLE
fix: filter maven pre-release fix versions from OSV enrichment

### DIFF
--- a/internal/sources/kev/client.go
+++ b/internal/sources/kev/client.go
@@ -44,7 +44,7 @@ type Client struct {
 
 func NewClientWithURL(url string) *Client {
 	return &Client{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		httpClient: &http.Client{Timeout: 60 * time.Second},
 		catalogURL: url,
 	}
 }

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -144,7 +144,7 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 	if best != "" && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
 		best = "v" + best
 	}
-	if mavenPreRelease.MatchString(best) {
+	if strings.HasPrefix(storedPurl, "pkg:maven/") && mavenPreRelease.MatchString(best) {
 		return ""
 	}
 	return best

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -141,7 +141,7 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 	}
 
 	best = matchClassifier(best, installedRaw)
-	if best != "" && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
+	if strings.HasPrefix(storedPurl, "pkg:golang/") && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
 		best = "v" + best
 	}
 	if strings.HasPrefix(storedPurl, "pkg:maven/") && mavenPreRelease.MatchString(best) {

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -144,6 +144,9 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 	if best != "" && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
 		best = "v" + best
 	}
+	if mavenPreRelease.MatchString(best) {
+		return ""
+	}
 	return best
 }
 
@@ -255,4 +258,5 @@ var (
 	ghsaPattern          = regexp.MustCompile(`GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}`)
 	nonSemverSuffix      = regexp.MustCompile(`\.[A-Za-z][A-Za-z0-9]*$`)
 	fourthNumericSegment = regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\d+$`)
+	mavenPreRelease      = regexp.MustCompile(`(?i)\.(M[0-9]+|RC[0-9]+|alpha|beta|SNAPSHOT)$`)
 )

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -258,5 +258,5 @@ var (
 	ghsaPattern          = regexp.MustCompile(`GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}`)
 	nonSemverSuffix      = regexp.MustCompile(`\.[A-Za-z][A-Za-z0-9]*$`)
 	fourthNumericSegment = regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\d+$`)
-	mavenPreRelease      = regexp.MustCompile(`(?i)\.(M[0-9]+|RC[0-9]+|alpha|beta|SNAPSHOT)$`)
+	mavenPreRelease      = regexp.MustCompile(`(?i)[.\-](M[0-9]+|RC[0-9]+|alpha[0-9]*|beta[0-9]*|SNAPSHOT)$`)
 )

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -122,12 +122,18 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 	var best string
 	var bestSemver semver.Version
 
+	typ := purlType(storedPurl)
+	isMaven := typ == purlTypeMaven
+
 	for _, a := range record.Affected {
 		if a.Package.Purl == "" || !strings.EqualFold(purlBase(a.Package.Purl), base) {
 			continue
 		}
 		candidate, candidateSemver, ok := minFixFromRanges(a.Ranges, installed, installedOk)
 		if !ok {
+			continue
+		}
+		if isMaven && isMavenPreRelease(candidate) {
 			continue
 		}
 		if installedOk {
@@ -140,12 +146,8 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 		}
 	}
 
-	typ := purlType(storedPurl)
-	if typ == "maven" && mavenPreRelease.MatchString(best) {
-		return ""
-	}
 	best = matchClassifier(best, installedRaw)
-	if best != "" && typ == "golang" && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
+	if best != "" && typ == purlTypeGolang && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
 		best = "v" + best
 	}
 	return best
@@ -233,5 +235,4 @@ var (
 	ghsaPattern          = regexp.MustCompile(`GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}`)
 	nonSemverSuffix      = regexp.MustCompile(`\.[A-Za-z][A-Za-z0-9]*$`)
 	fourthNumericSegment = regexp.MustCompile(`^(\d+\.\d+\.\d+)\.\d+$`)
-	mavenPreRelease      = regexp.MustCompile(`(?i)[.\-](M[0-9]+|RC[0-9]+|alpha[0-9]*|beta[0-9]*|SNAPSHOT)$`)
 )

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -140,11 +140,12 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 		}
 	}
 
-	if strings.HasPrefix(storedPurl, "pkg:maven/") && mavenPreRelease.MatchString(best) {
+	typ := purlType(storedPurl)
+	if typ == "maven" && mavenPreRelease.MatchString(best) {
 		return ""
 	}
 	best = matchClassifier(best, installedRaw)
-	if best != "" && strings.HasPrefix(storedPurl, "pkg:golang/") && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
+	if best != "" && typ == "golang" && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
 		best = "v" + best
 	}
 	return best
@@ -205,32 +206,6 @@ func matchClassifier(fix, installedRaw string) string {
 
 func isGHSA(id string) bool {
 	return strings.HasPrefix(id, "GHSA-")
-}
-
-func purlBase(purl string) string {
-	if i := strings.IndexByte(purl, '?'); i >= 0 {
-		purl = purl[:i]
-	}
-	if i := strings.IndexByte(purl, '#'); i >= 0 {
-		purl = purl[:i]
-	}
-	if i := strings.IndexByte(purl, '@'); i >= 0 {
-		purl = purl[:i]
-	}
-	return purl
-}
-
-func purlVersion(purl string) string {
-	if i := strings.IndexByte(purl, '?'); i >= 0 {
-		purl = purl[:i]
-	}
-	if i := strings.IndexByte(purl, '#'); i >= 0 {
-		purl = purl[:i]
-	}
-	if _, after, ok := strings.Cut(purl, "@"); ok {
-		return after
-	}
-	return ""
 }
 
 func parseSemver(v string) (semver.Version, bool) {

--- a/internal/sources/osv/client.go
+++ b/internal/sources/osv/client.go
@@ -140,12 +140,12 @@ func FixVersionForPurl(record *VulnRecord, storedPurl string) string {
 		}
 	}
 
-	best = matchClassifier(best, installedRaw)
-	if strings.HasPrefix(storedPurl, "pkg:golang/") && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
-		best = "v" + best
-	}
 	if strings.HasPrefix(storedPurl, "pkg:maven/") && mavenPreRelease.MatchString(best) {
 		return ""
+	}
+	best = matchClassifier(best, installedRaw)
+	if best != "" && strings.HasPrefix(storedPurl, "pkg:golang/") && strings.HasPrefix(installedRaw, "v") && !strings.HasPrefix(best, "v") {
+		best = "v" + best
 	}
 	return best
 }

--- a/internal/sources/osv/osv_test.go
+++ b/internal/sources/osv/osv_test.go
@@ -496,6 +496,66 @@ func TestFixVersionForPurl(t *testing.T) {
 			purl:     "pkg:maven/org.example/lib@1.5.0",
 			expected: "2.0.1",
 		},
+		{
+			name: "maven M1 hyphen separator ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "11.0.0-M1"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "",
+		},
+		{
+			name: "maven RC hyphen separator ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "3.0.0-RC2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "",
+		},
+		{
+			name: "maven SNAPSHOT hyphen separator ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0-SNAPSHOT"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "",
+		},
+		{
+			name: "non-maven RC not filtered",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:npm/foo"},
+						Ranges: []osv.Range{
+							{Type: "SEMVER", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0-RC1"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:npm/foo@1.5.0",
+			expected: "2.0.0-RC1",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/sources/osv/osv_test.go
+++ b/internal/sources/osv/osv_test.go
@@ -540,6 +540,27 @@ func TestFixVersionForPurl(t *testing.T) {
 			expected: "2.0.1",
 		},
 		{
+			name: "maven pre-release and stable fix in same range: stable fix returned",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0.M2"}}},
+						},
+					},
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "2.0.0",
+		},
+		{
 			name: "maven M1 hyphen separator ignored",
 			record: &osv.VulnRecord{
 				Affected: []osv.Affected{

--- a/internal/sources/osv/osv_test.go
+++ b/internal/sources/osv/osv_test.go
@@ -436,6 +436,66 @@ func TestFixVersionForPurl(t *testing.T) {
 			purl:     "pkg:nuget/Microsoft.NETCore.App.Runtime.linux-musl-x64@8.0.24",
 			expected: "8.0.26",
 		},
+		{
+			name: "maven M1 pre-release fix ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.apache.commons/commons-fileupload2-core"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "2.0.0"}, {Fixed: "2.0.0.M2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.apache.commons/commons-fileupload2-core@2.0.0.M1",
+			expected: "",
+		},
+		{
+			name: "maven RC pre-release fix ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "3.0.0"}, {Fixed: "3.0.0.RC2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@3.0.0.RC1",
+			expected: "",
+		},
+		{
+			name: "maven SNAPSHOT fix ignored",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0.SNAPSHOT"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "",
+		},
+		{
+			name: "maven stable fix not filtered",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.1"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "2.0.1",
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/sources/osv/osv_test.go
+++ b/internal/sources/osv/osv_test.go
@@ -497,7 +497,7 @@ func TestFixVersionForPurl(t *testing.T) {
 			expected: "",
 		},
 		{
-			name: "golang v-prefix: fix version gets v prefix to match installed",
+			name: "golang v-prefix: mixed-case purl type still gets v prefix",
 			record: &osv.VulnRecord{
 				Affected: []osv.Affected{
 					{
@@ -508,7 +508,7 @@ func TestFixVersionForPurl(t *testing.T) {
 					},
 				},
 			},
-			purl:     "pkg:golang/github.com/jackc/pgx/v5@v5.5.4",
+			purl:     "pkg:Golang/github.com/jackc/pgx/v5@v5.5.4",
 			expected: "v5.9.2",
 		},
 		{
@@ -600,18 +600,18 @@ func TestFixVersionForPurl(t *testing.T) {
 			expected: "2.0.0-RC1",
 		},
 		{
-			name: "maven hyphen RC pre-release fix not smuggled through classifier rewrite",
+			name: "maven pre-release filter applies with mixed-case purl type",
 			record: &osv.VulnRecord{
 				Affected: []osv.Affected{
 					{
 						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
 						Ranges: []osv.Range{
-							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "10.0.0"}, {Fixed: "11.0.0-RC2"}}},
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0.M1"}}},
 						},
 					},
 				},
 			},
-			purl:     "pkg:maven/org.example/lib@10.1.0-jre",
+			purl:     "pkg:Maven/org.example/lib@1.5.0",
 			expected: "",
 		},
 	}

--- a/internal/sources/osv/osv_test.go
+++ b/internal/sources/osv/osv_test.go
@@ -443,12 +443,12 @@ func TestFixVersionForPurl(t *testing.T) {
 					{
 						Package: osv.AffectedPackage{Purl: "pkg:maven/org.apache.commons/commons-fileupload2-core"},
 						Ranges: []osv.Range{
-							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "2.0.0"}, {Fixed: "2.0.0.M2"}}},
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0.M2"}}},
 						},
 					},
 				},
 			},
-			purl:     "pkg:maven/org.apache.commons/commons-fileupload2-core@2.0.0.M1",
+			purl:     "pkg:maven/org.apache.commons/commons-fileupload2-core@1.5.0",
 			expected: "",
 		},
 		{
@@ -458,12 +458,27 @@ func TestFixVersionForPurl(t *testing.T) {
 					{
 						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
 						Ranges: []osv.Range{
-							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "3.0.0"}, {Fixed: "3.0.0.RC2"}}},
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "2.0.0"}, {Fixed: "3.0.0.RC2"}}},
 						},
 					},
 				},
 			},
-			purl:     "pkg:maven/org.example/lib@3.0.0.RC1",
+			purl:     "pkg:maven/org.example/lib@2.9.0",
+			expected: "",
+		},
+		{
+			name: "maven hyphen RC pre-release fix not smuggled through classifier rewrite",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "10.0.0"}, {Fixed: "11.0.0-RC2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@10.1.0-jre",
 			expected: "",
 		},
 		{
@@ -479,6 +494,34 @@ func TestFixVersionForPurl(t *testing.T) {
 				},
 			},
 			purl:     "pkg:maven/org.example/lib@1.5.0",
+			expected: "",
+		},
+		{
+			name: "golang v-prefix: fix version gets v prefix to match installed",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:golang/github.com/jackc/pgx/v5"},
+						Ranges: []osv.Range{
+							{Type: "SEMVER", Events: []osv.Event{{Introduced: "0"}, {Fixed: "5.9.2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:golang/github.com/jackc/pgx/v5@v5.5.4",
+			expected: "v5.9.2",
+		},
+		{
+			name: "golang no fix — empty string not prefixed with v",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:golang/stdlib"},
+						Ranges:  []osv.Range{},
+					},
+				},
+			},
+			purl:     "pkg:golang/stdlib@v1.23.12",
 			expected: "",
 		},
 		{
@@ -555,6 +598,21 @@ func TestFixVersionForPurl(t *testing.T) {
 			},
 			purl:     "pkg:npm/foo@1.5.0",
 			expected: "2.0.0-RC1",
+		},
+		{
+			name: "maven hyphen RC pre-release fix not smuggled through classifier rewrite",
+			record: &osv.VulnRecord{
+				Affected: []osv.Affected{
+					{
+						Package: osv.AffectedPackage{Purl: "pkg:maven/org.example/lib"},
+						Ranges: []osv.Range{
+							{Type: "ECOSYSTEM", Events: []osv.Event{{Introduced: "10.0.0"}, {Fixed: "11.0.0-RC2"}}},
+						},
+					},
+				},
+			},
+			purl:     "pkg:maven/org.example/lib@10.1.0-jre",
+			expected: "",
 		},
 	}
 

--- a/internal/sources/osv/purl.go
+++ b/internal/sources/osv/purl.go
@@ -1,0 +1,38 @@
+package osv
+
+import "strings"
+
+func purlType(purl string) string {
+	s := strings.ToLower(purl)
+	s = strings.TrimPrefix(s, "pkg:")
+	if before, _, ok := strings.Cut(s, "/"); ok {
+		return before
+	}
+	return s
+}
+
+func purlBase(purl string) string {
+	if i := strings.IndexByte(purl, '?'); i >= 0 {
+		purl = purl[:i]
+	}
+	if i := strings.IndexByte(purl, '#'); i >= 0 {
+		purl = purl[:i]
+	}
+	if i := strings.IndexByte(purl, '@'); i >= 0 {
+		purl = purl[:i]
+	}
+	return purl
+}
+
+func purlVersion(purl string) string {
+	if i := strings.IndexByte(purl, '?'); i >= 0 {
+		purl = purl[:i]
+	}
+	if i := strings.IndexByte(purl, '#'); i >= 0 {
+		purl = purl[:i]
+	}
+	if _, after, ok := strings.Cut(purl, "@"); ok {
+		return after
+	}
+	return ""
+}

--- a/internal/sources/osv/purl.go
+++ b/internal/sources/osv/purl.go
@@ -1,6 +1,25 @@
 package osv
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	purlTypeMaven  = "maven"
+	purlTypeGolang = "golang"
+	purlTypeNpm    = "npm"
+	purlTypePypi   = "pypi"
+	purlTypeCargo  = "cargo"
+	purlTypeNuget  = "nuget"
+	purlTypeGem    = "gem"
+)
+
+var mavenPreReleasePattern = regexp.MustCompile(`(?i)[.\-](M[0-9]+|RC[0-9]+|alpha[0-9]*|beta[0-9]*|SNAPSHOT)$`)
+
+func isMavenPreRelease(version string) bool {
+	return mavenPreReleasePattern.MatchString(version)
+}
 
 func purlType(purl string) string {
 	s := strings.ToLower(purl)


### PR DESCRIPTION
OSV range boundaries sometimes land on milestone or RC versions (e.g. 2.0.0.M2, 3.0.0.RC1, SNAPSHOT). These are not installable in production so treat them as no fix found. Filter applied at the end of FixVersionForPurl so the next sync clears affected rows via BulkClearFixVersions (~1200 rows in prod).