### PR TITLE
fix: add www.cisa.gov to FQDNNetworkPolicy egress rules

### DIFF
--- a/charts/templates/fqdnnetpol.yaml
+++ b/charts/templates/fqdnnetpol.yaml
@@ -19,6 +19,7 @@ spec:
     - fqdns:
       - private.googleapis.com
       - cisa.gov
+      - www.cisa.gov
       - api.osv.dev
       - ttl.sh
       - sigstore-tuf-root.storage.googleapis.com


### PR DESCRIPTION
## Summary

- KEV sync was failing daily at 06:00 UTC with `dial tcp: i/o timeout` against `www.cisa.gov`
- Root cause: GKE `FQDNNetworkPolicy` wildcards only match one subdomain level — `cisa.gov` does **not** cover `www.cisa.gov`
- Fix: add `www.cisa.gov` explicitly alongside the existing `cisa.gov` entry in `fqdnnetpol.yaml`

## Testing

Deploy to cluster and verify the next KEV sync job completes without timeout.