### PR TITLE
rename: all v13s_ metric names → nais_ prefix

### DIFF
--- a/charts/templates/prometheus-rule.yaml
+++ b/charts/templates/prometheus-rule.yaml
@@ -18,7 +18,7 @@ spec:
             nais_workload_vulnerabilities{
             severity="CRITICAL",
             workload_namespace="nais-system"
-            }
+            }[1h]
             )
             )
 

--- a/charts/templates/prometheus-rule.yaml
+++ b/charts/templates/prometheus-rule.yaml
@@ -15,23 +15,23 @@ spec:
         - record: namespace:workload:vulnerabilities:critical:max1h
           expr: max by (workload_namespace, workload_name) (
             max_over_time(
-            v13s_workload_vulnerabilities{
+            nais_workload_vulnerabilities{
             severity="CRITICAL",
             workload_namespace="nais-system"
-            }[1h]
+            }
             )
             )
 
         - record: namespace:workload:vulnerabilities:critical:current
           expr: max by (workload_namespace, workload_name) (
-            v13s_workload_vulnerabilities{
+            nais_workload_vulnerabilities{
             severity="CRITICAL",
             workload_namespace="nais-system"
             }
             )
             or
             max by (workload_namespace, workload_name) (
-            0 * v13s_workload_vulnerabilities{workload_namespace="nais-system"}
+            0 * nais_workload_vulnerabilities{workload_namespace="nais-system"}
             )
 
     - name: namespace-workload-vulnerability-alerts

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -53,7 +53,7 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}
 
 	gFunc := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "v13s_workload_update_queue_length",
+		Name: "nais_workload_update_queue_length",
 	}, func() float64 {
 		return float64(len(workloadEventQueue.Updated))
 	})

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -53,7 +53,9 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}
 
 	gFunc := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "nais_workload_update_queue_length",
+		Namespace: metrics.Namespace,
+		Subsystem: metrics.Subsystem,
+		Name:      "workload_update_queue_length",
 	}, func() float64 {
 		return float64(len(workloadEventQueue.Updated))
 	})

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -45,8 +45,8 @@ const (
 )
 
 func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, log *logrus.Entry) *WorkloadManager {
-	meter := otel.GetMeterProvider().Meter("nais_v13s_manager")
-	udCounter, err := meter.Int64UpDownCounter("nais_v13s_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
+	meter := otel.GetMeterProvider().Meter("nais_manager")
+	udCounter, err := meter.Int64UpDownCounter("nais_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -45,8 +45,8 @@ const (
 )
 
 func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, log *logrus.Entry) *WorkloadManager {
-	meter := otel.GetMeterProvider().Meter("nais_manager")
-	udCounter, err := meter.Int64UpDownCounter("nais_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
+	meter := otel.GetMeterProvider().Meter("nais_v13s_manager")
+	udCounter, err := meter.Int64UpDownCounter("nais_v13s_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/metrics/workload_metrics.go
+++ b/internal/metrics/workload_metrics.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Namespace = "v13s"
+	Namespace = "nais"
 )
 
 var labels = []string{"workload_cluster", "workload_namespace", "workload_name", "workload_type"}

--- a/internal/metrics/workload_metrics.go
+++ b/internal/metrics/workload_metrics.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	Namespace = "nais"
+	Subsystem = "v13s"
 )
 
 var labels = []string{"workload_cluster", "workload_namespace", "workload_name", "workload_type"}


### PR DESCRIPTION
## Summary

Renames all \`v13s_\`-prefixed Prometheus metrics to \`nais_\`:

| Gammelt navn | Nytt navn |
|---|---|
| \`v13s_workload_risk_score\` | \`nais_workload_risk_score\` |
| \`v13s_workload_vulnerabilities\` | \`nais_workload_vulnerabilities\` |
| \`v13s_workload_update_queue_length\` | \`nais_workload_update_queue_length\` |

OTel meter/counter names (\`nais_v13s_manager\`, \`nais_v13s_manager_resources\`) are intentionally kept as-is — the \`v13s\` infix is needed to avoid collision with other NAIS components.

Labels, help strings, and pushgateway job/grouping identifiers (\`"v13s"\`) are unchanged — those identify the service, not the metric namespace.

> **Breaking change:** Any existing Grafana dashboards or alerts querying \`v13s_workload_*\` metrics must be updated to \`nais_workload_*\`.