### PR TITLE
fix: skip MarkImagesForResync for images where all workloads are unrecoverable

### DIFF
--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -137,15 +137,7 @@ WHERE
     AND images.updated_at < @threshold_time
     AND images.state != 'resync'
     AND images.state != ANY (@excluded_states::image_state[])
-    AND EXISTS (
-        SELECT
-            1
-        FROM
-            workloads w2
-        WHERE
-            w2.image_name = images.name
-            AND w2.image_tag = images.tag
-            AND w2.state != 'unrecoverable');
+    AND w.state != 'unrecoverable';
 
 -- name: MarkUntrackedImagesForResync :execrows
 UPDATE

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -136,7 +136,16 @@ WHERE
     AND images.tag = w.image_tag
     AND images.updated_at < @threshold_time
     AND images.state != 'resync'
-    AND images.state != ANY (@excluded_states::image_state[]);
+    AND images.state != ANY (@excluded_states::image_state[])
+    AND EXISTS (
+        SELECT
+            1
+        FROM
+            workloads w2
+        WHERE
+            w2.image_name = images.name
+            AND w2.image_tag = images.tag
+            AND w2.state != 'unrecoverable');
 
 -- name: MarkUntrackedImagesForResync :execrows
 UPDATE

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -200,12 +200,7 @@ WHERE
     AND images.updated_at < $1
     AND images.state != 'resync'
     AND images.state != ANY ($2::image_state[])
-    AND EXISTS (
-        SELECT 1 FROM workloads w2
-        WHERE w2.image_name = images.name
-          AND w2.image_tag  = images.tag
-          AND w2.state != 'unrecoverable'
-    )
+    AND w.state != 'unrecoverable'
 `
 
 type MarkImagesForResyncParams struct {

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -200,6 +200,12 @@ WHERE
     AND images.updated_at < $1
     AND images.state != 'resync'
     AND images.state != ANY ($2::image_state[])
+    AND EXISTS (
+        SELECT 1 FROM workloads w2
+        WHERE w2.image_name = images.name
+          AND w2.image_tag  = images.tag
+          AND w2.state != 'unrecoverable'
+    )
 `
 
 type MarkImagesForResyncParams struct {

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -624,8 +624,8 @@ func TestUpdater(t *testing.T) {
 
 		// Set first workload to unrecoverable, second stays processing
 		_, err = pool.Exec(ctx,
-			"UPDATE workloads SET state = 'unrecoverable' WHERE name = $1 AND image_name = $2",
-			fmt.Sprintf("workload-%s", imageName), imageName)
+			"UPDATE workloads SET state = 'unrecoverable' WHERE name = $1 AND workload_type = 'app' AND namespace = 'namespace-1' AND cluster = 'cluster-1' AND image_name = $2 AND image_tag = $3",
+			fmt.Sprintf("workload-%s", imageName), imageName, imageVersion)
 		assert.NoError(t, err)
 
 		// Set image state to 'updated' (resync-eligible), old enough to be picked up by MarkForResync.

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -587,9 +587,12 @@ func TestUpdater(t *testing.T) {
 			imageName, imageVersion)
 		assert.NoError(t, err)
 
-		// Set image state to failed, old enough to be picked up by MarkForResync
+		// Set image to 'updated' (resync-eligible) old enough to be picked up by MarkForResync.
+		// Using 'updated' rather than 'failed' because MarkForResync excludes 'failed' via
+		// ExcludedStates — we need a state that would normally trigger a resync so we can confirm
+		// the unrecoverable-workload filter is what prevents it.
 		_, err = pool.Exec(ctx,
-			"UPDATE images SET state = 'failed', updated_at = $1 WHERE name = $2 AND tag = $3",
+			"UPDATE images SET state = 'updated', updated_at = $1 WHERE name = $2 AND tag = $3",
 			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
 			imageName, imageVersion)
 		assert.NoError(t, err)
@@ -601,7 +604,7 @@ func TestUpdater(t *testing.T) {
 
 		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
 		assert.NoError(t, err)
-		assert.Equal(t, sql.ImageStateFailed, image.State,
+		assert.Equal(t, sql.ImageStateUpdated, image.State,
 			"image with only unrecoverable workloads must not be reset to resync by MarkForResync")
 	})
 
@@ -625,9 +628,10 @@ func TestUpdater(t *testing.T) {
 			fmt.Sprintf("workload-%s", imageName), imageName)
 		assert.NoError(t, err)
 
-		// Set image state to failed, old enough to be picked up by MarkForResync
+		// Set image state to 'updated' (resync-eligible), old enough to be picked up by MarkForResync.
+		// Using 'updated' rather than 'failed' because MarkForResync excludes 'failed' via ExcludedStates.
 		_, err = pool.Exec(ctx,
-			"UPDATE images SET state = 'failed', updated_at = $1 WHERE name = $2 AND tag = $3",
+			"UPDATE images SET state = 'updated', updated_at = $1 WHERE name = $2 AND tag = $3",
 			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
 			imageName, imageVersion)
 		assert.NoError(t, err)

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -573,6 +573,76 @@ func TestUpdater(t *testing.T) {
 			"ready_for_resync_at of an already-resync image must not be overwritten by MarkForResync")
 	})
 
+	t.Run("MarkForResync skips images where all workloads are unrecoverable", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-unrecoverable"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		// Set the workload state to unrecoverable
+		_, err = pool.Exec(ctx,
+			"UPDATE workloads SET state = 'unrecoverable' WHERE image_name = $1 AND image_tag = $2",
+			imageName, imageVersion)
+		assert.NoError(t, err)
+
+		// Set image state to failed, old enough to be picked up by MarkForResync
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = 'failed', updated_at = $1 WHERE name = $2 AND tag = $3",
+			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
+			imageName, imageVersion)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()), config.KevConfig{}, config.OsvConfig{})
+
+		err = u.MarkForResync(ctx)
+		assert.NoError(t, err)
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateFailed, image.State,
+			"image with only unrecoverable workloads must not be reset to resync by MarkForResync")
+	})
+
+	t.Run("MarkForResync resets image when at least one workload is not unrecoverable", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		assert.NoError(t, err)
+
+		imageName := "project-mixed"
+		imageVersion := "v1"
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		// Add a second workload for the same image
+		_, err = pool.Exec(ctx,
+			"INSERT INTO workloads (name, workload_type, namespace, cluster, image_name, image_tag, state) VALUES ($1, 'app', 'namespace-1', 'cluster-1', $2, $3, 'processing')",
+			"workload-extra", imageName, imageVersion)
+		assert.NoError(t, err)
+
+		// Set first workload to unrecoverable, second stays processing
+		_, err = pool.Exec(ctx,
+			"UPDATE workloads SET state = 'unrecoverable' WHERE name = $1 AND image_name = $2",
+			fmt.Sprintf("workload-%s", imageName), imageName)
+		assert.NoError(t, err)
+
+		// Set image state to failed, old enough to be picked up by MarkForResync
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = 'failed', updated_at = $1 WHERE name = $2 AND tag = $3",
+			time.Now().Add(-updater.ResyncImagesOlderThanMinutesDefault-time.Hour),
+			imageName, imageVersion)
+		assert.NoError(t, err)
+
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, make(chan struct{}), logrus.NewEntry(logrus.StandardLogger()), config.KevConfig{}, config.OsvConfig{})
+
+		err = u.MarkForResync(ctx)
+		assert.NoError(t, err)
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageVersion})
+		assert.NoError(t, err)
+		assert.Equal(t, sql.ImageStateResync, image.State,
+			"image with at least one non-unrecoverable workload must be reset to resync by MarkForResync")
+	})
+
 	t.Run("images ready for resync after SBOM upload", func(t *testing.T) {
 		ctx = context.Background()
 


### PR DESCRIPTION
## Problem

Images where all workloads are `unrecoverable` (e.g. GKE system images, vendor images without Sigstore attestation) were being continuously reset to `resync` state by the scheduled `MarkImagesForResync` job. This caused an infinite loop:

1. `get_attestation` exhausts all retries → `image.state = failed`
2. `MarkImagesForResync` resets `image.state = resync` (did not exclude these images)
3. Updater picks up the image, fails again → back to `failed`
4. Repeat indefinitely

27 images were observed in this state in local (GKE system images, ingress-nginx, and several team images).

## Fix

Added an `EXISTS` subquery to `MarkImagesForResync` that excludes images where all associated workloads are `unrecoverable`. Images with at least one non-unrecoverable workload continue to be resynced normally.

## Manual remediation required after deploy

The 27 images already stuck in `unrecoverable + resync` state today will not be fixed automatically. Run this once against the database after deploying:

```sql
UPDATE images
SET
    state = 'failed',
    updated_at = NOW()
WHERE state = 'resync'
  AND NOT EXISTS (
      SELECT 1 FROM workloads w
      WHERE w.image_name = images.name
        AND w.image_tag  = images.tag
        AND w.state != 'unrecoverable'
  );
```

## Tests

Two new integration tests added to `updater_integration_test.go`:
- `MarkForResync skips images where all workloads are unrecoverable`
- `MarkForResync resets image when at least one workload is not unrecoverable`