### PR TITLE
fix: use independent context for River database migration on startup

### DIFF
--- a/internal/job/client.go
+++ b/internal/job/client.go
@@ -62,7 +62,9 @@ func NewClient(ctx context.Context, cfg *Config, queues map[string]river.QueueCo
 		return nil, err
 	}
 
-	if err := migrate(ctx, pool); err != nil {
+	migrateCtx, cancelMigrate := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancelMigrate()
+	if err := migrate(migrateCtx, pool); err != nil {
 		return nil, fmt.Errorf("failed to migrate database: %w", err)
 	}
 


### PR DESCRIPTION
## Problem

On deploy, the process was consistently failing with:

```
{"level":"fatal","msg":"Failed to create job client: failed to migrate database: failed to get migrator versions: error checking if `river_migration` exists: context canceled"}
```

Followed immediately by:

```
{"level":"fatal","msg":"timed out waiting for watchers to be ready"}
```

## Root cause

`job.NewClient` passed the application context directly to `migrate()`, which used it for `migrator.ExistingVersions(ctx)`. The app context is created with `signal.NotifyContext` and gets cancelled on `SIGTERM`/`SIGINT`. During a rolling deploy, Kubernetes sends `SIGTERM` to the old pod while the new pod is starting up — if the signal arrives during the River migration, the migration fails with `context canceled`.

The watcher timeout is a secondary consequence: `log.Fatalf` calls `os.Exit(1)` immediately, so the K8s informer code is never reached. The 1-second gap in logs confirms the context was already cancelled when `WaitForReady` was called.

## Fix

Use `context.Background()` with an explicit 2-minute timeout for the migration context, independent of the application lifecycle. Migration is a one-shot startup operation that should always complete on its own terms.