### PR TITLE
fix: start HTTP server before WaitForReady to prevent liveness probe failure

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             failureThreshold: 5
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 8000
             initialDelaySeconds: 20
             periodSeconds: 5

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -133,7 +133,6 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	if !informerMgr.WaitForReady(syncCtx) {
 		log.Fatalf("timed out waiting for watchers to be ready")
 	}
-	ready.Store(true)
 
 	u := updater.NewUpdater(
 		pool,
@@ -151,7 +150,7 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	u.Run(ctx)
 
 	wg.Go(func() error {
-		if err = runGrpcServer(ctx, cfg, pool, mgr, u, log); err != nil {
+		if err = runGrpcServer(ctx, cfg, pool, mgr, u, log, func() { ready.Store(true) }); err != nil {
 			log.WithError(err).Errorf("error in GRPC server")
 			return err
 		}
@@ -177,12 +176,13 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	return nil
 }
 
-func runGrpcServer(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, mgr *manager.WorkloadManager, u *updater.Updater, log logrus.FieldLogger) error {
+func runGrpcServer(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, mgr *manager.WorkloadManager, u *updater.Updater, log logrus.FieldLogger, onReady func()) error {
 	log.Info("GRPC serving on ", cfg.ListenAddr)
 	lis, err := net.Listen("tcp", cfg.ListenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
+	onReady()
 
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -131,6 +131,9 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	syncCtx, cancelSync := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelSync()
 	if !informerMgr.WaitForReady(syncCtx) {
+		if ctx.Err() != nil {
+			return fmt.Errorf("context cancelled before watchers became ready: %w", ctx.Err())
+		}
 		log.Fatalf("timed out waiting for watchers to be ready")
 	}
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -182,7 +182,6 @@ func runGrpcServer(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, 
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
-	onReady()
 
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
@@ -196,7 +195,10 @@ func runGrpcServer(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, 
 	management.RegisterManagementServer(s, grpcmgmt.NewServer(ctx, pool, mgr, u, log.WithField("subsystem", "management")))
 
 	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error { return s.Serve(lis) })
+	g.Go(func() error {
+		onReady()
+		return s.Serve(lis)
+	})
 	g.Go(func() error {
 		<-ctx.Done()
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -129,16 +129,22 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 
 	syncCtx, cancelSync := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelSync()
-	if !informerMgr.WaitForReady(syncCtx) {
-		select {
-		case err := <-httpErrCh:
-			return fmt.Errorf("HTTP server failed before watchers became ready: %w", err)
-		default:
+
+	syncDone := make(chan bool, 1)
+	go func() {
+		syncDone <- informerMgr.WaitForReady(syncCtx)
+	}()
+
+	select {
+	case err := <-httpErrCh:
+		return fmt.Errorf("HTTP server failed before watchers became ready: %w", err)
+	case ready := <-syncDone:
+		if !ready {
+			if ctx.Err() != nil {
+				return fmt.Errorf("context cancelled before watchers became ready: %w", ctx.Err())
+			}
+			log.Fatalf("timed out waiting for watchers to be ready")
 		}
-		if ctx.Err() != nil {
-			return fmt.Errorf("context cancelled before watchers became ready: %w", ctx.Err())
-		}
-		log.Fatalf("timed out waiting for watchers to be ready")
 	}
 
 	u := updater.NewUpdater(

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -102,6 +102,21 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		DbUrl: cfg.DatabaseUrl,
 	}
 
+	ready := &atomic.Bool{}
+
+	httpErrCh := make(chan error, 1)
+	go func() {
+		httpErrCh <- runInternalHTTPServer(
+			ctx,
+			cfg.InternalListenAddr,
+			promReg,
+			pool,
+			ready,
+			log,
+			Handler{"/riverui", riverUI(ctx, jobCfg.DbUrl)},
+		)
+	}()
+
 	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, log.WithField("subsystem", "manager"))
 	mgr.Start(ctx)
 	defer mgr.Stop(ctx)
@@ -112,25 +127,14 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}
 	defer informerMgr.Stop()
 
-	ready := &atomic.Bool{}
-
-	wg, ctx := errgroup.WithContext(ctx)
-
-	wg.Go(func() error {
-		return runInternalHTTPServer(
-			ctx,
-			cfg.InternalListenAddr,
-			promReg,
-			pool,
-			ready,
-			log,
-			Handler{"/riverui", riverUI(ctx, jobCfg.DbUrl)},
-		)
-	})
-
 	syncCtx, cancelSync := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelSync()
 	if !informerMgr.WaitForReady(syncCtx) {
+		select {
+		case err := <-httpErrCh:
+			return fmt.Errorf("HTTP server failed before watchers became ready: %w", err)
+		default:
+		}
 		if ctx.Err() != nil {
 			return fmt.Errorf("context cancelled before watchers became ready: %w", ctx.Err())
 		}
@@ -151,6 +155,17 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		cfg.Osv,
 	)
 	u.Run(ctx)
+
+	wg, ctx := errgroup.WithContext(ctx)
+
+	wg.Go(func() error {
+		select {
+		case err := <-httpErrCh:
+			return err
+		case <-ctx.Done():
+			return nil
+		}
+	})
 
 	wg.Go(func() error {
 		if err = runGrpcServer(ctx, cfg, pool, mgr, u, log, func() { ready.Store(true) }); err != nil {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -111,11 +112,28 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}
 	defer informerMgr.Stop()
 
+	ready := &atomic.Bool{}
+
+	wg, ctx := errgroup.WithContext(ctx)
+
+	wg.Go(func() error {
+		return runInternalHTTPServer(
+			ctx,
+			cfg.InternalListenAddr,
+			promReg,
+			pool,
+			ready,
+			log,
+			Handler{"/riverui", riverUI(ctx, jobCfg.DbUrl)},
+		)
+	})
+
 	syncCtx, cancelSync := context.WithTimeout(ctx, 60*time.Second)
 	defer cancelSync()
 	if !informerMgr.WaitForReady(syncCtx) {
 		log.Fatalf("timed out waiting for watchers to be ready")
 	}
+	ready.Store(true)
 
 	u := updater.NewUpdater(
 		pool,
@@ -132,25 +150,12 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	)
 	u.Run(ctx)
 
-	wg, ctx := errgroup.WithContext(ctx)
-
 	wg.Go(func() error {
 		if err = runGrpcServer(ctx, cfg, pool, mgr, u, log); err != nil {
 			log.WithError(err).Errorf("error in GRPC server")
 			return err
 		}
 		return nil
-	})
-
-	wg.Go(func() error {
-		return runInternalHTTPServer(
-			ctx,
-			cfg.InternalListenAddr,
-			promReg,
-			pool,
-			log,
-			Handler{"/riverui", riverUI(ctx, jobCfg.DbUrl)},
-		)
 	})
 
 	<-ctx.Done()

--- a/internal/api/internal_http.go
+++ b/internal/api/internal_http.go
@@ -51,6 +51,14 @@ func runInternalHTTPServer(ctx context.Context, listenAddress string, reg promet
 			return
 		}
 
+		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+
+		if err := pool.Ping(ctx); err != nil {
+			http.Error(w, "db unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write([]byte("ok")); err != nil {
 			log.WithError(err).Error("failed to write readyz response")

--- a/internal/api/internal_http.go
+++ b/internal/api/internal_http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -25,10 +26,15 @@ type Handler struct {
 	Handler http.Handler
 }
 
-func runInternalHTTPServer(ctx context.Context, listenAddress string, reg prometheus.Gatherer, pool *pgxpool.Pool, log logrus.FieldLogger, extraHandlers ...Handler) error {
+func runInternalHTTPServer(ctx context.Context, listenAddress string, reg prometheus.Gatherer, pool *pgxpool.Pool, ready *atomic.Bool, log logrus.FieldLogger, extraHandlers ...Handler) error {
 	router := chi.NewRouter()
 	router.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "starting up", http.StatusServiceUnavailable)
+			return
+		}
+
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 

--- a/internal/api/internal_http.go
+++ b/internal/api/internal_http.go
@@ -29,12 +29,8 @@ type Handler struct {
 func runInternalHTTPServer(ctx context.Context, listenAddress string, reg prometheus.Gatherer, pool *pgxpool.Pool, ready *atomic.Bool, log logrus.FieldLogger, extraHandlers ...Handler) error {
 	router := chi.NewRouter()
 	router.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		if !ready.Load() {
-			http.Error(w, "starting up", http.StatusServiceUnavailable)
-			return
-		}
 
+	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel()
 
@@ -46,6 +42,18 @@ func runInternalHTTPServer(ctx context.Context, listenAddress string, reg promet
 		w.WriteHeader(http.StatusOK)
 		if _, err := w.Write([]byte("ok")); err != nil {
 			log.WithError(err).Error("failed to write healthz response")
+		}
+	})
+
+	router.Get("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "starting up", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("ok")); err != nil {
+			log.WithError(err).Error("failed to write readyz response")
 		}
 	})
 


### PR DESCRIPTION
## Problem

On pod restarts, Kubernetes liveness probes fire immediately (no \`initialDelaySeconds\` grace period applies on restarts). The HTTP server on port 8000 was previously started **after** \`WaitForReady\`, meaning liveness probes would get \`connection refused\` during the informer cache sync phase (~60s). After \`failureThreshold: 5\` failures, Kubernetes kills the container via SIGTERM — which cancels \`ctx\` — causing \`WaitForCacheSync\` to return \`false\` immediately, triggering \`log.Fatalf\` and a crash loop.

## Fix

Two distinct endpoints with clear semantics:

**\`/healthz\` — liveness only**
- Returns 200 as long as the database is reachable
- Never blocked by startup state
- Liveness probe uses this endpoint → the pod is never killed during informer sync or gRPC bind

**\`/readyz\` — readiness**
- Returns 503 \`starting up\` until both:
  1. Informer cache sync completes (\`WaitForReady\`)
  2. gRPC server is constructed, services registered, and \`Serve\` is about to be called (\`onReady\` callback)
- After startup, also verifies database connectivity (db ping)
- Readiness probe uses this endpoint → no traffic is routed to the pod before it can serve gRPC requests

Helm chart updated: \`livenessProbe\` uses \`/healthz\`, \`readinessProbe\` uses \`/readyz\`.

## Root cause discovery

Found via debug logging added in \`WaitForReady\` which confirmed \`context canceled\` was the failure mode, then traced to liveness probe events:
```
Warning  Unhealthy  Liveness probe failed: dial tcp ...:8000: connect: connection refused
Normal   Killing    Container v13s failed liveness probe, will be restarted
```