### PR TITLE
fix: update workload states to updated after successful resync

### DIFF
--- a/internal/database/queries/workloads.sql
+++ b/internal/database/queries/workloads.sql
@@ -214,3 +214,14 @@ ORDER BY
         namespace,
         CLUSTER,
         updated_at) DESC;
+
+-- name: BatchUpdateWorkloadStateByImage :batchexec
+UPDATE
+    workloads
+SET
+    state = @state,
+    updated_at = NOW()
+WHERE
+    image_name = @image_name
+    AND image_tag = @image_tag
+    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation');

--- a/internal/database/sql/batch.go
+++ b/internal/database/sql/batch.go
@@ -75,6 +75,65 @@ func (b *BatchUpdateImageStateBatchResults) Close() error {
 	return b.br.Close()
 }
 
+const batchUpdateWorkloadStateByImage = `-- name: BatchUpdateWorkloadStateByImage :batchexec
+UPDATE
+    workloads
+SET
+    state = $1,
+    updated_at = NOW()
+WHERE
+    image_name = $2
+    AND image_tag = $3
+    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation')
+`
+
+type BatchUpdateWorkloadStateByImageBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+type BatchUpdateWorkloadStateByImageParams struct {
+	State     WorkloadState
+	ImageName string
+	ImageTag  string
+}
+
+func (q *Queries) BatchUpdateWorkloadStateByImage(ctx context.Context, arg []BatchUpdateWorkloadStateByImageParams) *BatchUpdateWorkloadStateByImageBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range arg {
+		vals := []interface{}{
+			a.State,
+			a.ImageName,
+			a.ImageTag,
+		}
+		batch.Queue(batchUpdateWorkloadStateByImage, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &BatchUpdateWorkloadStateByImageBatchResults{br, len(arg), false}
+}
+
+func (b *BatchUpdateWorkloadStateByImageBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, ErrBatchAlreadyClosed)
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *BatchUpdateWorkloadStateByImageBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
 const batchUpsertCve = `-- name: BatchUpsertCve :batchexec
 INSERT INTO cve(
     cve_id,

--- a/internal/database/sql/querier.go
+++ b/internal/database/sql/querier.go
@@ -12,6 +12,7 @@ type Querier interface {
 	AddWorkloadEvent(ctx context.Context, arg AddWorkloadEventParams) error
 	AdvisoryUnlock(ctx context.Context, key int64) (bool, error)
 	BatchUpdateImageState(ctx context.Context, arg []BatchUpdateImageStateParams) *BatchUpdateImageStateBatchResults
+	BatchUpdateWorkloadStateByImage(ctx context.Context, arg []BatchUpdateWorkloadStateByImageParams) *BatchUpdateWorkloadStateByImageBatchResults
 	BatchUpsertCve(ctx context.Context, arg []BatchUpsertCveParams) *BatchUpsertCveBatchResults
 	BatchUpsertCveAlias(ctx context.Context, arg []BatchUpsertCveAliasParams) *BatchUpsertCveAliasBatchResults
 	BatchUpsertVulnerabilities(ctx context.Context, arg []BatchUpsertVulnerabilitiesParams) *BatchUpsertVulnerabilitiesBatchResults

--- a/internal/mocks/Querier/mock_querier.go
+++ b/internal/mocks/Querier/mock_querier.go
@@ -177,6 +177,55 @@ func (_c *MockQuerier_BatchUpdateImageState_Call) RunAndReturn(run func(context.
 	return _c
 }
 
+// BatchUpdateWorkloadStateByImage provides a mock function with given fields: ctx, arg
+func (_m *MockQuerier) BatchUpdateWorkloadStateByImage(ctx context.Context, arg []sql.BatchUpdateWorkloadStateByImageParams) *sql.BatchUpdateWorkloadStateByImageBatchResults {
+	ret := _m.Called(ctx, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BatchUpdateWorkloadStateByImage")
+	}
+
+	var r0 *sql.BatchUpdateWorkloadStateByImageBatchResults
+	if rf, ok := ret.Get(0).(func(context.Context, []sql.BatchUpdateWorkloadStateByImageParams) *sql.BatchUpdateWorkloadStateByImageBatchResults); ok {
+		r0 = rf(ctx, arg)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.BatchUpdateWorkloadStateByImageBatchResults)
+		}
+	}
+
+	return r0
+}
+
+// MockQuerier_BatchUpdateWorkloadStateByImage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BatchUpdateWorkloadStateByImage'
+type MockQuerier_BatchUpdateWorkloadStateByImage_Call struct {
+	*mock.Call
+}
+
+// BatchUpdateWorkloadStateByImage is a helper method to define mock.On call
+//   - ctx context.Context
+//   - arg []sql.BatchUpdateWorkloadStateByImageParams
+func (_e *MockQuerier_Expecter) BatchUpdateWorkloadStateByImage(ctx interface{}, arg interface{}) *MockQuerier_BatchUpdateWorkloadStateByImage_Call {
+	return &MockQuerier_BatchUpdateWorkloadStateByImage_Call{Call: _e.mock.On("BatchUpdateWorkloadStateByImage", ctx, arg)}
+}
+
+func (_c *MockQuerier_BatchUpdateWorkloadStateByImage_Call) Run(run func(ctx context.Context, arg []sql.BatchUpdateWorkloadStateByImageParams)) *MockQuerier_BatchUpdateWorkloadStateByImage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]sql.BatchUpdateWorkloadStateByImageParams))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_BatchUpdateWorkloadStateByImage_Call) Return(_a0 *sql.BatchUpdateWorkloadStateByImageBatchResults) *MockQuerier_BatchUpdateWorkloadStateByImage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockQuerier_BatchUpdateWorkloadStateByImage_Call) RunAndReturn(run func(context.Context, []sql.BatchUpdateWorkloadStateByImageParams) *sql.BatchUpdateWorkloadStateByImageBatchResults) *MockQuerier_BatchUpdateWorkloadStateByImage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // BatchUpsertCve provides a mock function with given fields: ctx, arg
 func (_m *MockQuerier) BatchUpsertCve(ctx context.Context, arg []sql.BatchUpsertCveParams) *sql.BatchUpsertCveBatchResults {
 	ret := _m.Called(ctx, arg)

--- a/internal/updater/db.go
+++ b/internal/updater/db.go
@@ -34,18 +34,21 @@ func NewDbContext(ctx context.Context, querier sql.Querier, log *logrus.Entry) c
 // SyncImage runs the provided function and updates the image state in the database based on the result, it should only return an error if the image state update failed.
 func SyncImage(ctx context.Context, imageName, imageTag, source string, f func(ctx context.Context) error) error {
 	d := db(ctx)
-	err := f(ctx)
-	if err != nil {
-		err = handleError(ctx, imageName, imageTag, source, err)
+	srcErr := f(ctx)
+	if srcErr != nil {
+		err := handleError(ctx, imageName, imageTag, source, srcErr)
 		if err != nil {
-			n, err := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			if errors.Is(srcErr, sources.ErrNoProject) {
+				return err
+			}
+			n, updateErr := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
 				Name:  imageName,
 				Tag:   imageTag,
 				State: sql.ImageStateFailed,
 			})
-			if err != nil {
-				d.log.Errorf("failed to update image state: %v", err)
-				return fmt.Errorf("updating image state: %w", err)
+			if updateErr != nil {
+				d.log.Errorf("failed to update image state: %v", updateErr)
+				return fmt.Errorf("updating image state: %w", updateErr)
 			}
 			if n == 0 {
 				d.log.Warnf("UpdateImageState matched no rows for image %s:%s, image may already be gone", imageName, imageTag)
@@ -61,7 +64,7 @@ func SyncImage(ctx context.Context, imageName, imageTag, source string, f func(c
 		State: sql.ImageStateUpdated,
 	})*/
 
-	return err
+	return nil
 }
 
 func db(ctx context.Context) *database {
@@ -76,7 +79,31 @@ func handleError(ctx context.Context, imageName, imageTag string, source string,
 		Source:    source,
 	}
 
-	if err == nil || errors.Is(err, sources.ErrNoProject) || errors.Is(err, sources.ErrNoMetrics) {
+	if err == nil || errors.Is(err, sources.ErrNoMetrics) {
+		return nil
+	}
+
+	if errors.Is(err, sources.ErrNoProject) {
+		if dbErr := d.querier.UpdateWorkloadStateByImage(ctx, sql.UpdateWorkloadStateByImageParams{
+			ImageName: imageName,
+			ImageTag:  imageTag,
+			State:     sql.WorkloadStateNoAttestation,
+		}); dbErr != nil {
+			d.log.Errorf("failed to update workload state to no_attestation: %v", dbErr)
+			return fmt.Errorf("updating workload state: %w", dbErr)
+		}
+		n, dbErr := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:  imageName,
+			Tag:   imageTag,
+			State: sql.ImageStateFailed,
+		})
+		if dbErr != nil {
+			d.log.Errorf("failed to update image state to failed: %v", dbErr)
+			return fmt.Errorf("updating image state: %w", dbErr)
+		}
+		if n == 0 {
+			d.log.Warnf("UpdateImageState matched no rows for image %s:%s, image may already be gone", imageName, imageTag)
+		}
 		return nil
 	}
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -285,7 +285,9 @@ func (u *Updater) Update(ctx context.Context, ch chan *ImageVulnerabilityData) e
 			break
 		}
 
-		u.BatchUpdateVulnerabilityData(ctx, batch)
+		if err := u.BatchUpdateVulnerabilityData(ctx, batch); err != nil {
+			return err
+		}
 	}
 
 	u.log.WithFields(logrus.Fields{
@@ -295,7 +297,7 @@ func (u *Updater) Update(ctx context.Context, ch chan *ImageVulnerabilityData) e
 	return nil
 }
 
-func (u *Updater) BatchUpdateVulnerabilityData(ctx context.Context, images []*ImageVulnerabilityData) {
+func (u *Updater) BatchUpdateVulnerabilityData(ctx context.Context, images []*ImageVulnerabilityData) error {
 	cves := make([]sql.BatchUpsertCveParams, 0)
 	cveAliases := make([]sql.BatchUpsertCveAliasParams, 0)
 	vulns := make([]sql.BatchUpsertVulnerabilitiesParams, 0)
@@ -341,7 +343,25 @@ func (u *Updater) BatchUpdateVulnerabilityData(ctx context.Context, images []*Im
 		}
 	}
 
+	workloadStates := make([]sql.BatchUpdateWorkloadStateByImageParams, 0, len(images))
+	for _, i := range images {
+		workloadStates = append(workloadStates, sql.BatchUpdateWorkloadStateByImageParams{
+			State:     sql.WorkloadStateUpdated,
+			ImageName: i.ImageName,
+			ImageTag:  i.ImageTag,
+		})
+	}
+	sortByFields(workloadStates,
+		func(x sql.BatchUpdateWorkloadStateByImageParams) string { return x.ImageName },
+		func(x sql.BatchUpdateWorkloadStateByImageParams) string { return x.ImageTag },
+	)
+	if errCount := u.runExec("update workload states", len(workloadStates), u.querier.BatchUpdateWorkloadStateByImage(ctx, workloadStates).Exec); errCount > 0 {
+		u.log.Errorf("skipping image state update: %d workload state update(s) failed", errCount)
+		return fmt.Errorf("batch workload state update had %d failure(s), image state update skipped", errCount)
+	}
+
 	u.runExec("update image states", len(images), u.querier.BatchUpdateImageState(ctx, imageStates).Exec)
+	return nil
 }
 
 func (u *Updater) runExec(

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -692,6 +692,197 @@ func TestUpdater(t *testing.T) {
 		assert.Equal(t, imageName, images[0].Name)
 		assert.Equal(t, imageTag, images[0].Tag)
 	})
+
+	t.Run("workloads in processing state should be set to updated after resync", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		require.NoError(t, err)
+
+		imageName := projectNames[0]
+		imageTag := "v1"
+
+		insertWorkloads(ctx, t, db, []string{imageName})
+
+		_, err = pool.Exec(ctx,
+			"UPDATE workloads SET state = 'processing' WHERE image_name = $1 AND image_tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET metadata = '{}', state = 'resync', ready_for_resync_at = NOW() WHERE name = $1 AND tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+
+		updaterCtx, cancel := context.WithDeadline(ctx, time.Now().Add(10*time.Second))
+		defer cancel()
+
+		done = make(chan struct{})
+		u = updater.NewUpdater(pool, sourceMock, mgr, updateSchedule, done, logrus.NewEntry(logrus.StandardLogger()), config.KevConfig{}, config.OsvConfig{})
+
+		err = u.ResyncImageVulnerabilities(updaterCtx)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for updater to complete")
+		}
+
+		workloads, err := pool.Query(ctx,
+			"SELECT state FROM workloads WHERE image_name = $1 AND image_tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+		defer workloads.Close()
+		checkedAny := false
+		for workloads.Next() {
+			checkedAny = true
+			var state string
+			require.NoError(t, workloads.Scan(&state))
+			assert.Equal(t, string(sql.WorkloadStateUpdated), state,
+				"workload in processing should be set to updated after resync")
+		}
+		require.NoError(t, workloads.Err())
+		require.True(t, checkedAny, "expected at least one workload row to be checked")
+	})
+
+	t.Run("SyncImage with ErrNoProject sets image to failed and workload to no_attestation and returns nil", func(t *testing.T) {
+		err = db.ResetDatabase(ctx)
+		require.NoError(t, err)
+
+		imageName := "no-project-image"
+		imageTag := "v1"
+
+		err = db.CreateImage(ctx, sql.CreateImageParams{
+			Name:     imageName,
+			Tag:      imageTag,
+			Metadata: map[string]string{},
+		})
+		require.NoError(t, err)
+
+		_, err = pool.Exec(ctx,
+			"UPDATE images SET state = 'resync', ready_for_resync_at = NOW() WHERE name = $1 AND tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+
+		_, err = db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+			Name:         "workload-no-project",
+			WorkloadType: "app",
+			Namespace:    "namespace-1",
+			Cluster:      "cluster-1",
+			ImageName:    imageName,
+			ImageTag:     imageTag,
+		})
+		if !errors.Is(err, pgx.ErrNoRows) {
+			require.NoError(t, err)
+		}
+
+		_, err = pool.Exec(ctx,
+			"UPDATE workloads SET state = 'processing' WHERE image_name = $1 AND image_tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+
+		dbCtx := updater.NewDbContext(ctx, db, logrus.NewEntry(logrus.StandardLogger()))
+
+		syncErr := updater.SyncImage(dbCtx, imageName, imageTag, "dependencytrack", func(ctx context.Context) error {
+			return sources.ErrNoProject
+		})
+		assert.NoError(t, syncErr, "SyncImage should return nil for ErrNoProject")
+
+		image, err := db.GetImage(ctx, sql.GetImageParams{Name: imageName, Tag: imageTag})
+		require.NoError(t, err)
+		assert.Equal(t, sql.ImageStateFailed, image.State, "image should be set to failed")
+
+		rows, err := pool.Query(ctx,
+			"SELECT state FROM workloads WHERE image_name = $1 AND image_tag = $2",
+			imageName, imageTag)
+		require.NoError(t, err)
+		defer rows.Close()
+		checkedAny := false
+		for rows.Next() {
+			checkedAny = true
+			var state string
+			require.NoError(t, rows.Scan(&state))
+			assert.Equal(t, string(sql.WorkloadStateNoAttestation), state,
+				"workload should be set to no_attestation")
+		}
+		require.NoError(t, rows.Err())
+		require.True(t, checkedAny, "expected at least one workload row to be checked")
+	})
+}
+
+func TestBatchUpdateWorkloadStateByImage_TerminalStatesNotOverwritten(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	imageName := "batch-update-test-image"
+	imageTag := "v1"
+
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{
+		Name:     imageName,
+		Tag:      imageTag,
+		Metadata: map[string]string{},
+	}))
+
+	type workloadCase struct {
+		name          string
+		initialState  sql.WorkloadState
+		expectUpdated bool
+	}
+
+	cases := []workloadCase{
+		{"wl-processing", sql.WorkloadStateProcessing, true},
+		{"wl-updated", sql.WorkloadStateUpdated, true},
+		{"wl-failed", sql.WorkloadStateFailed, false},
+		{"wl-unrecoverable", sql.WorkloadStateUnrecoverable, false},
+		{"wl-no-attestation", sql.WorkloadStateNoAttestation, false},
+	}
+
+	for _, c := range cases {
+		_, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+			Name:         c.name,
+			WorkloadType: "app",
+			Namespace:    "namespace-1",
+			Cluster:      "cluster-1",
+			ImageName:    imageName,
+			ImageTag:     imageTag,
+		})
+		if !errors.Is(err, pgx.ErrNoRows) {
+			require.NoError(t, err)
+		}
+		_, err = pool.Exec(ctx,
+			"UPDATE workloads SET state = $1 WHERE name = $2 AND image_name = $3 AND image_tag = $4",
+			string(c.initialState), c.name, imageName, imageTag)
+		require.NoError(t, err)
+	}
+
+	db.BatchUpdateWorkloadStateByImage(ctx, []sql.BatchUpdateWorkloadStateByImageParams{
+		{
+			State:     sql.WorkloadStateUpdated,
+			ImageName: imageName,
+			ImageTag:  imageTag,
+		},
+	}).Exec(func(_ int, err error) {
+		require.NoError(t, err)
+	})
+
+	for _, c := range cases {
+		var state string
+		err := pool.QueryRow(ctx,
+			"SELECT state FROM workloads WHERE name = $1 AND image_name = $2 AND image_tag = $3",
+			c.name, imageName, imageTag,
+		).Scan(&state)
+		require.NoError(t, err)
+
+		if c.expectUpdated {
+			assert.Equal(t, string(sql.WorkloadStateUpdated), state,
+				"workload %s with initial state %s should be updated", c.name, c.initialState)
+		} else {
+			assert.Equal(t, string(c.initialState), state,
+				"workload %s with terminal state %s should not be overwritten", c.name, c.initialState)
+		}
+	}
 }
 
 func TestUpdater_DetermineSeveritySince(t *testing.T) {


### PR DESCRIPTION
## Problem
Workloads remained stuck in `processing` after a successful vulnerability resync. Images with no project source (`ErrNoProject`) were not transitioned to a terminal state.

## Changes
- Add `BatchUpdateWorkloadStateByImage` query; update all non-terminal workloads to `updated` after successful resync
- `ErrNoProject`: set workloads to `no_attestation`, image to `failed`
- Terminal states (`failed`, `unrecoverable`, `no_attestation`) are never overwritten
- Integration tests covering stuck-state fix and terminal-state invariant