### PR TITLE
fix: surface batch/upsert failures, prevent producer deadlock, propagate update errors

### DIFF
--- a/internal/updater/db.go
+++ b/internal/updater/db.go
@@ -41,19 +41,16 @@ func SyncImage(ctx context.Context, imageName, imageTag, source string, f func(c
 			if errors.Is(srcErr, sources.ErrNoProject) {
 				return err
 			}
-			n, updateErr := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
-				Name:  imageName,
-				Tag:   imageTag,
-				State: sql.ImageStateFailed,
-			})
-			if updateErr != nil {
-				d.log.Errorf("failed to update image state: %v", updateErr)
-				return fmt.Errorf("updating image state: %w", updateErr)
-			}
-			if n == 0 {
+		if n, updateErr := d.querier.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:  imageName,
+			Tag:   imageTag,
+			State: sql.ImageStateFailed,
+		}); updateErr != nil {
+			d.log.Errorf("failed to update image state: %v", updateErr)
+		} else if n == 0 {
 				d.log.Warnf("UpdateImageState matched no rows for image %s:%s, image may already be gone", imageName, imageTag)
 			}
-			return nil
+			return err
 		}
 		return nil
 	}
@@ -116,5 +113,5 @@ func handleError(ctx context.Context, imageName, imageTag string, source string,
 		return fmt.Errorf("updating image sync status: %w", insertErr)
 	}
 
-	return err
+	return nil
 }

--- a/internal/updater/source.go
+++ b/internal/updater/source.go
@@ -36,7 +36,11 @@ func (u *Updater) FetchVulnerabilityDataForImages(ctx context.Context, images []
 					return err
 				}
 
-				ch <- imageData
+				select {
+				case ch <- imageData:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 				return nil
 			})
 		})

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -160,34 +161,32 @@ func (u *Updater) ResyncImageVulnerabilities(ctx context.Context) error {
 
 	ctx = NewDbContext(ctx, u.querier, u.log)
 
-	done := make(chan bool)
+	done := make(chan error, 1)
 	batchCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 
 	ch := make(chan *ImageVulnerabilityData, 100)
 
 	go func() {
-		defer close(done)
-		if err := u.Update(batchCtx, ch); err != nil {
-			u.log.WithError(err).Error("Failed to batch insert image vulnerability data")
-			done <- false
-		} else {
-			done <- true
-		}
+		done <- u.Update(batchCtx, cancel, ch)
 	}()
 
-	// TODO: riverjob worker to fetch vulnerability data for images
-	err = u.FetchVulnerabilityDataForImages(ctx, images, FetchVulnerabilityDataForImagesDefaultLimit, ch)
+	fetchErr := u.FetchVulnerabilityDataForImages(batchCtx, images, FetchVulnerabilityDataForImagesDefaultLimit, ch)
 	close(ch)
 
-	updateSuccess := <-done
+	updateErr := <-done
 
-	if err != nil {
-		u.log.WithError(err).Error("Failed to fetch vulnerability data for images")
-		return err
+	if updateErr != nil {
+		u.log.WithError(updateErr).Error("failed to batch insert image vulnerability data")
+		return updateErr
 	}
 
-	u.log.Infof("images resynced successfully: %v, in %fs", updateSuccess, time.Since(start).Seconds())
+	if fetchErr != nil && !errors.Is(fetchErr, context.Canceled) {
+		u.log.WithError(fetchErr).Error("failed to fetch vulnerability data for images")
+		return fetchErr
+	}
+
+	u.log.Infof("images resynced successfully in %fs", time.Since(start).Seconds())
 
 	if u.doneChan != nil {
 		u.once.Do(func() {
@@ -272,12 +271,16 @@ func (u *Updater) MarkForResync(ctx context.Context) error {
 	return nil
 }
 
-func (u *Updater) Update(ctx context.Context, ch chan *ImageVulnerabilityData) error {
+func (u *Updater) Update(ctx context.Context, cancel context.CancelFunc, ch chan *ImageVulnerabilityData) error {
 	start := time.Now()
+	var firstErr error
 
 	for {
 		batch, err := collections.ReadChannel(ctx, ch, 100)
 		if err != nil {
+			if firstErr != nil {
+				return firstErr
+			}
 			return err
 		}
 
@@ -286,8 +289,14 @@ func (u *Updater) Update(ctx context.Context, ch chan *ImageVulnerabilityData) e
 		}
 
 		if err := u.BatchUpdateVulnerabilityData(ctx, batch); err != nil {
-			return err
+			firstErr = err
+			cancel()
+			continue
 		}
+	}
+
+	if firstErr != nil {
+		return firstErr
 	}
 
 	u.log.WithFields(logrus.Fields{
@@ -330,9 +339,13 @@ func (u *Updater) BatchUpdateVulnerabilityData(ctx context.Context, images []*Im
 		func(x sql.BatchUpdateImageStateParams) string { return x.Tag },
 	)
 
-	u.runExec("upsert CVEs", len(cves), u.querier.BatchUpsertCve(ctx, cves).Exec)
-	u.runExec("upsert CVE aliases", len(cveAliases), u.querier.BatchUpsertCveAlias(ctx, cveAliases).Exec)
-	u.runExec("upsert vulnerabilities", len(vulns), u.querier.BatchUpsertVulnerabilities(ctx, vulns).Exec)
+	upsertErrs := u.runExec("upsert CVEs", len(cves), u.querier.BatchUpsertCve(ctx, cves).Exec)
+	upsertErrs += u.runExec("upsert CVE aliases", len(cveAliases), u.querier.BatchUpsertCveAlias(ctx, cveAliases).Exec)
+	upsertErrs += u.runExec("upsert vulnerabilities", len(vulns), u.querier.BatchUpsertVulnerabilities(ctx, vulns).Exec)
+
+	if upsertErrs > 0 {
+		return fmt.Errorf("vulnerability data upsert had %d failure(s), skipping state updates", upsertErrs)
+	}
 
 	for _, i := range images {
 		if err := u.querier.RecalculateVulnerabilitySummary(ctx, sql.RecalculateVulnerabilitySummaryParams{
@@ -360,7 +373,9 @@ func (u *Updater) BatchUpdateVulnerabilityData(ctx context.Context, images []*Im
 		return fmt.Errorf("batch workload state update had %d failure(s), image state update skipped", errCount)
 	}
 
-	u.runExec("update image states", len(images), u.querier.BatchUpdateImageState(ctx, imageStates).Exec)
+	if errCount := u.runExec("update image states", len(images), u.querier.BatchUpdateImageState(ctx, imageStates).Exec); errCount > 0 {
+		return fmt.Errorf("batch image state update had %d failure(s)", errCount)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem
Several robustness gaps in the resync pipeline: upsert errors were silently dropped, a producer goroutine could deadlock if the consumer exited early, and batch state update failures were not propagated.

## Changes
- `updater.go`: accumulate and return upsert errors before state updates; surface `BatchUpdateImageState` failure; cancel-drain pattern on first error in `Update`; `ResyncImageVulnerabilities` uses `chan error` and suppresses `context.Canceled`
- `db.go`: `SyncImage` returns error (not nil) on non-`ErrNoProject` fallback; `handleError` returns nil after successful `UpdateImageSyncStatus`
- `source.go`: `select` on `ctx.Done()` when sending to channel to prevent producer deadlock