### PR TITLE
fix: preserve sbom_processing_started_at across resync re-entries

### DIFF
--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -51,10 +51,8 @@ SET
     state = @state,
     ready_for_resync_at = @ready_for_resync_at,
     sbom_processing_started_at = CASE WHEN @state::image_state IN ('resync', 'initialized')
-        AND sbom_processing_started_at IS NULL THEN
+        AND state NOT IN ('resync', 'initialized') THEN
         NOW()
-    WHEN @state::image_state NOT IN ('resync', 'initialized') THEN
-        NULL
     ELSE
         sbom_processing_started_at
     END,
@@ -138,7 +136,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
+    sbom_processing_started_at = NOW(),
     updated_at = NOW()
 FROM
     workloads w
@@ -156,7 +154,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
+    sbom_processing_started_at = NOW(),
     updated_at = NOW()
 WHERE
     state = 'untracked'

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -50,10 +50,13 @@ UPDATE
 SET
     state = @state,
     ready_for_resync_at = @ready_for_resync_at,
-    sbom_processing_started_at = CASE WHEN @state::image_state IN ('resync', 'initialized') THEN
+    sbom_processing_started_at = CASE WHEN @state::image_state IN ('resync', 'initialized')
+        AND sbom_processing_started_at IS NULL THEN
         NOW()
-    ELSE
+    WHEN @state::image_state NOT IN ('resync', 'initialized') THEN
         NULL
+    ELSE
+        sbom_processing_started_at
     END,
     updated_at = NOW()
 WHERE
@@ -135,7 +138,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = NOW(),
+    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
     updated_at = NOW()
 FROM
     workloads w
@@ -153,7 +156,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = NOW(),
+    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
     updated_at = NOW()
 WHERE
     state = 'untracked'

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -56,6 +56,8 @@ SET
         sbom_processing_started_at
     WHEN @state::image_state IN ('resync', 'initialized') THEN
         NOW()
+    WHEN @state::image_state = 'updated' THEN
+        sbom_processing_started_at
     ELSE
         NULL
     END,

--- a/internal/database/queries/image.sql
+++ b/internal/database/queries/image.sql
@@ -51,10 +51,13 @@ SET
     state = @state,
     ready_for_resync_at = @ready_for_resync_at,
     sbom_processing_started_at = CASE WHEN @state::image_state IN ('resync', 'initialized')
-        AND state NOT IN ('resync', 'initialized') THEN
+        AND state IN ('resync', 'initialized')
+        AND sbom_processing_started_at IS NOT NULL THEN
+        sbom_processing_started_at
+    WHEN @state::image_state IN ('resync', 'initialized') THEN
         NOW()
     ELSE
-        sbom_processing_started_at
+        NULL
     END,
     updated_at = NOW()
 WHERE

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -309,8 +309,11 @@ SET
     ready_for_resync_at = $2,
     sbom_processing_started_at = CASE
         WHEN $1::image_state IN ('resync', 'initialized')
-            AND state NOT IN ('resync', 'initialized') THEN NOW()
-        ELSE sbom_processing_started_at
+            AND state IN ('resync', 'initialized')
+            AND sbom_processing_started_at IS NOT NULL
+            THEN sbom_processing_started_at
+        WHEN $1::image_state IN ('resync', 'initialized') THEN NOW()
+        ELSE NULL
     END,
     updated_at = NOW()
 WHERE

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -195,7 +195,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
+    sbom_processing_started_at = NOW(),
     updated_at = NOW()
 FROM
     workloads w
@@ -224,7 +224,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
+    sbom_processing_started_at = NOW(),
     updated_at = NOW()
 WHERE
     state = 'untracked'
@@ -308,8 +308,8 @@ SET
     state = $1,
     ready_for_resync_at = $2,
     sbom_processing_started_at = CASE
-        WHEN $1::image_state IN ('resync', 'initialized') AND sbom_processing_started_at IS NULL THEN NOW()
-        WHEN $1::image_state NOT IN ('resync', 'initialized') THEN NULL
+        WHEN $1::image_state IN ('resync', 'initialized')
+            AND state NOT IN ('resync', 'initialized') THEN NOW()
         ELSE sbom_processing_started_at
     END,
     updated_at = NOW()

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -307,13 +307,16 @@ UPDATE
 SET
     state = $1,
     ready_for_resync_at = $2,
-    sbom_processing_started_at = CASE
-        WHEN $1::image_state IN ('resync', 'initialized')
-            AND state IN ('resync', 'initialized')
-            AND sbom_processing_started_at IS NOT NULL
-            THEN sbom_processing_started_at
-        WHEN $1::image_state IN ('resync', 'initialized') THEN NOW()
-        ELSE NULL
+    sbom_processing_started_at = CASE WHEN $1::image_state IN ('resync', 'initialized')
+        AND state IN ('resync', 'initialized')
+        AND sbom_processing_started_at IS NOT NULL THEN
+        sbom_processing_started_at
+    WHEN $1::image_state IN ('resync', 'initialized') THEN
+        NOW()
+    WHEN $1::image_state = 'updated' THEN
+        sbom_processing_started_at
+    ELSE
+        NULL
     END,
     updated_at = NOW()
 WHERE

--- a/internal/database/sql/image.sql.go
+++ b/internal/database/sql/image.sql.go
@@ -195,7 +195,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = NOW(),
+    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
     updated_at = NOW()
 FROM
     workloads w
@@ -224,7 +224,7 @@ UPDATE
 SET
     state = 'resync',
     ready_for_resync_at = NOW(),
-    sbom_processing_started_at = NOW(),
+    sbom_processing_started_at = COALESCE(sbom_processing_started_at, NOW()),
     updated_at = NOW()
 WHERE
     state = 'untracked'
@@ -307,10 +307,10 @@ UPDATE
 SET
     state = $1,
     ready_for_resync_at = $2,
-    sbom_processing_started_at = CASE WHEN $1::image_state IN ('resync', 'initialized') THEN
-        NOW()
-    ELSE
-        NULL
+    sbom_processing_started_at = CASE
+        WHEN $1::image_state IN ('resync', 'initialized') AND sbom_processing_started_at IS NULL THEN NOW()
+        WHEN $1::image_state NOT IN ('resync', 'initialized') THEN NULL
+        ELSE sbom_processing_started_at
     END,
     updated_at = NOW()
 WHERE


### PR DESCRIPTION
## Problem
The SBOM processing timer resets mid-flight. Any transition back to \`resync\` — suppress/unsuppress, manual nudge, or the periodic resync job — unconditionally overwrites \`sbom_processing_started_at\` with \`NOW()\`, causing the \"Processing for\" counter to restart from zero.

## Changes
- \`UpdateImageState\`: preserve timestamp when re-entering \`resync\`/\`initialized\` while already in-flight and stamped; stamp \`NOW()\` on fresh entry (including existing rows with \`NULL\`); preserve on \`updated\` so the UI can show \"last scan took X\"; clear on all inactive/terminal states (\`failed\`, \`untracked\`, \`unused\`, \`outdated\`)
- \`MarkImagesForResync\` / \`MarkUntrackedImagesForResync\`: unconditional \`NOW()\` — both already guard \`state != resync\` so always a fresh cycle