### PR TITLE
feat(summary): activate stale-tag fallback in GetVulnerabilitySummaryForImage

### DIFF
--- a/internal/api/grpcvulnerabilities/sbom_status.go
+++ b/internal/api/grpcvulnerabilities/sbom_status.go
@@ -31,6 +31,8 @@ func deriveImageSbomStatus(imageState *sql.ImageState) vulnerabilities.SbomStatu
 		return vulnerabilities.SbomStatus_SBOM_STATUS_READY
 	case sql.ImageStateFailed:
 		return vulnerabilities.SbomStatus_SBOM_STATUS_FAILED
+	case sql.ImageStateUnused:
+		return vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM
 	default:
 		return vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING
 	}

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2811,7 +2811,7 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 		require.NoError(t, err)
 		_, err = db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
 			Name:         "workload-1",
-			WorkloadType: "Deployment",
+			WorkloadType: "app",
 			Namespace:    "namespace-1",
 			Cluster:      "cluster-1",
 			ImageName:    imageName,

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2861,7 +2861,7 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING, resp.GetSbomStatus().GetStatus())
 	})
 
-	t.Run("unused image with existing summary returns READY status", func(t *testing.T) {
+	t.Run("unused image with existing summary returns NO_SBOM status", func(t *testing.T) {
 		const (
 			unusedImage = "image-unused-with-summary"
 			unusedTag   = "v4.0"
@@ -2885,7 +2885,7 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 		require.NotNil(t, sum)
 		assert.Equal(t, int32(3), sum.GetHigh())
 		assert.Nil(t, sum.StaleImageTag)
-		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_READY, resp.GetSbomStatus().GetStatus())
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM, resp.GetSbomStatus().GetStatus())
 	})
 
 	t.Run("unused image without summary returns NO_SBOM status", func(t *testing.T) {

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2777,3 +2777,61 @@ func TestServer_EnrichedCveFields(t *testing.T) {
 		assert.InDelta(t, enriched.GetCve().GetCvssScore(), enriched.GetCvssScore(), 0.0001)
 	})
 }
+
+func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
+	ctx, db, _, client, cleanup := setupTest(t, testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1"},
+		workloadsPerNamespace: 1,
+		vulnsPerWorkload:      1,
+	}, true)
+	defer cleanup()
+
+	const (
+		imageName = "image-cluster-1-namespace-1-workload-1"
+		knownTag  = "v1.0"
+		newTag    = "v2.0"
+	)
+
+	t.Run("unknown tag falls back to most recent known tag", func(t *testing.T) {
+		// v1.0 was seeded by setupTest with 1 high vuln; v2.0 has no summary yet.
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, imageName, newTag)
+		require.NoError(t, err)
+
+		sum := resp.GetVulnerabilitySummary()
+		require.NotNil(t, sum)
+		assert.Equal(t, int32(1), sum.GetHigh(), "stale counts from v1.0 must be returned")
+		require.NotNil(t, sum.StaleImageTag, "stale_image_tag must be set")
+		assert.Equal(t, knownTag, *sum.StaleImageTag, "stale_image_tag must point to v1.0")
+	})
+
+	t.Run("workload_ref and sbom_status are still populated when using stale summary", func(t *testing.T) {
+		// Register v2.0 as the current image for the workload so workload_ref is non-empty.
+		_, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+			Name:         "workload-1",
+			WorkloadType: "Deployment",
+			Namespace:    "namespace-1",
+			Cluster:      "cluster-1",
+			ImageName:    imageName,
+			ImageTag:     newTag,
+		})
+		require.NoError(t, err)
+		err = db.CreateImage(ctx, sql.CreateImageParams{Name: imageName, Tag: newTag, Metadata: map[string]string{}})
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, imageName, newTag)
+		require.NoError(t, err)
+		assert.NotEmpty(t, resp.GetWorkloadRef(), "workload_ref must be populated even with stale summary")
+		assert.NotNil(t, resp.GetSbomStatus(), "sbom_status must be populated")
+	})
+
+	t.Run("completely unknown image returns empty summary without error", func(t *testing.T) {
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, "never-seen-image", "v1.0")
+		require.NoError(t, err)
+
+		sum := resp.GetVulnerabilitySummary()
+		require.NotNil(t, sum)
+		assert.Nil(t, sum.StaleImageTag, "stale_image_tag must be nil when no prior tag exists")
+		assert.Equal(t, int32(0), sum.GetTotal())
+	})
+}

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2834,4 +2834,76 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 		assert.Nil(t, sum.StaleImageTag, "stale_image_tag must be nil when no prior tag exists")
 		assert.Equal(t, int32(0), sum.GetTotal())
 	})
+
+	t.Run("image in PROCESSING with existing summary but no workload record returns summary and PROCESSING status", func(t *testing.T) {
+		const (
+			processingImage = "image-processing-no-workload"
+			processingTag   = "v3.0"
+		)
+		err := db.CreateImage(ctx, sql.CreateImageParams{Name: processingImage, Tag: processingTag, Metadata: map[string]string{}})
+		require.NoError(t, err)
+
+		_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{
+			ImageName: processingImage,
+			ImageTag:  processingTag,
+			High:      5,
+			RiskScore: 25,
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, processingImage, processingTag)
+		require.NoError(t, err)
+
+		sum := resp.GetVulnerabilitySummary()
+		require.NotNil(t, sum)
+		assert.Equal(t, int32(5), sum.GetHigh(), "existing summary counts must be returned")
+		assert.Nil(t, sum.StaleImageTag, "stale_image_tag must be nil when summary is for the requested tag")
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING, resp.GetSbomStatus().GetStatus())
+	})
+
+	t.Run("unused image with existing summary returns READY status", func(t *testing.T) {
+		const (
+			unusedImage = "image-unused-with-summary"
+			unusedTag   = "v4.0"
+		)
+		err := db.CreateImage(ctx, sql.CreateImageParams{Name: unusedImage, Tag: unusedTag, Metadata: map[string]string{}})
+		require.NoError(t, err)
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{Name: unusedImage, Tag: unusedTag, State: sql.ImageStateUnused})
+		require.NoError(t, err)
+		_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{
+			ImageName: unusedImage,
+			ImageTag:  unusedTag,
+			High:      3,
+			RiskScore: 15,
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, unusedImage, unusedTag)
+		require.NoError(t, err)
+
+		sum := resp.GetVulnerabilitySummary()
+		require.NotNil(t, sum)
+		assert.Equal(t, int32(3), sum.GetHigh())
+		assert.Nil(t, sum.StaleImageTag)
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_READY, resp.GetSbomStatus().GetStatus())
+	})
+
+	t.Run("unused image without summary returns NO_SBOM status", func(t *testing.T) {
+		const (
+			unusedImage = "image-unused-no-summary"
+			unusedTag   = "v5.0"
+		)
+		err := db.CreateImage(ctx, sql.CreateImageParams{Name: unusedImage, Tag: unusedTag, Metadata: map[string]string{}})
+		require.NoError(t, err)
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{Name: unusedImage, Tag: unusedTag, State: sql.ImageStateUnused})
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerabilitySummaryForImage(ctx, unusedImage, unusedTag)
+		require.NoError(t, err)
+
+		sum := resp.GetVulnerabilitySummary()
+		require.NotNil(t, sum)
+		assert.Nil(t, sum.StaleImageTag)
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM, resp.GetSbomStatus().GetStatus())
+	})
 }

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2807,7 +2807,9 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 
 	t.Run("workload_ref and sbom_status are still populated when using stale summary", func(t *testing.T) {
 		// Register v2.0 as the current image for the workload so workload_ref is non-empty.
-		_, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+		err := db.CreateImage(ctx, sql.CreateImageParams{Name: imageName, Tag: newTag, Metadata: map[string]string{}})
+		require.NoError(t, err)
+		_, err = db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
 			Name:         "workload-1",
 			WorkloadType: "Deployment",
 			Namespace:    "namespace-1",
@@ -2815,8 +2817,6 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 			ImageName:    imageName,
 			ImageTag:     newTag,
 		})
-		require.NoError(t, err)
-		err = db.CreateImage(ctx, sql.CreateImageParams{Name: imageName, Tag: newTag, Metadata: map[string]string{}})
 		require.NoError(t, err)
 
 		resp, err := client.GetVulnerabilitySummaryForImage(ctx, imageName, newTag)

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -254,6 +254,13 @@ func (s *Server) GetVulnerabilitySummaryForImage(ctx context.Context, request *v
 		}
 		if imgErr == nil {
 			worstStatus = deriveImageSbomStatus(&img.State)
+			if img.State == sql.ImageStateUnused {
+				if summary != nil {
+					worstStatus = vulnerabilities.SbomStatus_SBOM_STATUS_READY
+				} else {
+					worstStatus = vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM
+				}
+			}
 			if isPendingSbomStatus(worstStatus) && img.SbomProcessingStartedAt.Valid {
 				earliestProcessingStartedAt = timestamppb.New(img.SbomProcessingStartedAt.Time)
 			}

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -254,13 +254,6 @@ func (s *Server) GetVulnerabilitySummaryForImage(ctx context.Context, request *v
 		}
 		if imgErr == nil {
 			worstStatus = deriveImageSbomStatus(&img.State)
-			if img.State == sql.ImageStateUnused {
-				if summary != nil {
-					worstStatus = vulnerabilities.SbomStatus_SBOM_STATUS_READY
-				} else {
-					worstStatus = vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM
-				}
-			}
 			if isPendingSbomStatus(worstStatus) && img.SbomProcessingStartedAt.Valid {
 				earliestProcessingStartedAt = timestamppb.New(img.SbomProcessingStartedAt.Time)
 			}

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -196,29 +196,19 @@ func (s *Server) GetVulnerabilitySummaryForImage(ctx context.Context, request *v
 		if !errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("failed to get vulnerability summary for image: %w", err)
 		}
-		// No vulnerability summary for this exact tag yet (e.g. first-time scan in progress).
-		// Fall through so we still populate workload_ref + workloads with SBOM state.
-		// VulnerabilitySummary will be empty (&Summary{}) to preserve backward-compatible
-		// semantics — nais/api cannot yet distinguish stale data from a real empty summary.
-		//
-		// TODO: activate stale-tag fallback once nais/api is updated. Before enabling,
-		// these three call sites in nais/api/internal/vulnerability/queries.go must be updated:
-		//   - GetImageHasSBOM (queries.go:156):        check StaleImageTag; return false when set
-		//   - GetImageVulnerabilitySummary (queries.go:354): surface StaleImageTag to callers
-		//   - ListWorkloadReferences (queries.go:25):  handle codes.NotFound explicitly
-		//
-		// staleSummary, fallbackErr := s.querier.GetLatestSummaryForImageName(ctx, sql.GetLatestSummaryForImageNameParams{
-		// 	ImageName:  request.ImageName,
-		// 	ExcludeTag: request.ImageTag,
-		// })
-		// if fallbackErr != nil && !errors.Is(fallbackErr, pgx.ErrNoRows) {
-		// 	return nil, fmt.Errorf("failed to get fallback vulnerability summary for image: %w", fallbackErr)
-		// }
-		// if fallbackErr == nil {
-		// 	summary = staleSummary
-		// 	staleTag = staleSummary.ImageTag
-		// }
-		summary = nil
+		staleSummary, fallbackErr := s.querier.GetLatestSummaryForImageName(ctx, sql.GetLatestSummaryForImageNameParams{
+			ImageName:  request.ImageName,
+			ExcludeTag: request.ImageTag,
+		})
+		if fallbackErr != nil && !errors.Is(fallbackErr, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("failed to get fallback vulnerability summary for image: %w", fallbackErr)
+		}
+		if fallbackErr == nil {
+			summary = staleSummary
+			staleTag = staleSummary.ImageTag
+		} else {
+			summary = nil
+		}
 	}
 
 	workloads, err := s.querier.ListWorkloadsByImage(ctx, sql.ListWorkloadsByImageParams{


### PR DESCRIPTION
## What

When a client requests a vulnerability summary for an image tag that has no data, fall back to the most recent summary for the same image name (stale tag). The response includes `stale_image_tag` to indicate the fallback was used.

## Why

Newly deployed images briefly have no vulnerability data. Without the fallback, callers get an empty response and have no useful information to show. The stale tag gives a good-enough signal while the new tag is being processed.

## Changes

- `summary.go`: uncomment and activate the stale-tag fallback in `GetVulnerabilitySummaryForImage`
- `server_test.go`: add `TestServer_GetVulnerabilitySummaryForImage_StaleFallback` with 3 subtests:
  - stale fallback is returned when exact tag has no data
  - `workload_ref` is still populated on fallback response
  - completely unknown image returns empty response with no error