### PR TITLE
feat: move exclude filters into Filter message, add namespaces inclusion filter

### DIFF
--- a/internal/api/grpcvulnerabilities/mttf.go
+++ b/internal/api/grpcvulnerabilities/mttf.go
@@ -1,3 +1,4 @@
+//lint:file-ignore SA1019 deprecated proto fields read intentionally for backwards compatibility
 package grpcvulnerabilities
 
 import (

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2068,16 +2068,17 @@ func TestServer_ListCveSummaries(t *testing.T) {
 	})
 
 	t.Run("no namespaces filter returns all results", func(t *testing.T) {
-		filtered, err := client.ListCveSummaries(ctx,
+		withoutFilter, err := client.ListCveSummaries(ctx, vulnerabilities.Limit(10))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, withoutFilter.Nodes)
+
+		withFilter, err := client.ListCveSummaries(ctx,
 			vulnerabilities.Limit(10),
 			vulnerabilities.NamespacesFilter("namespace-1"),
 		)
 		assert.NoError(t, err)
 
-		all, err := client.ListCveSummaries(ctx, vulnerabilities.Limit(10))
-		assert.NoError(t, err)
-
-		assert.GreaterOrEqual(t, len(all.Nodes), len(filtered.Nodes))
+		assert.GreaterOrEqual(t, len(withoutFilter.Nodes), len(withFilter.Nodes))
 	})
 
 	t.Run("empty namespaces filter returns all results", func(t *testing.T) {

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2067,7 +2067,7 @@ func TestServer_ListCveSummaries(t *testing.T) {
 		}
 	})
 
-	t.Run("empty namespaces filter returns all results", func(t *testing.T) {
+	t.Run("no namespaces filter returns all results", func(t *testing.T) {
 		filtered, err := client.ListCveSummaries(ctx,
 			vulnerabilities.Limit(10),
 			vulnerabilities.NamespacesFilter("namespace-1"),
@@ -2078,6 +2078,19 @@ func TestServer_ListCveSummaries(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.GreaterOrEqual(t, len(all.Nodes), len(filtered.Nodes))
+	})
+
+	t.Run("empty namespaces filter returns all results", func(t *testing.T) {
+		withEmpty, err := client.ListCveSummaries(ctx,
+			vulnerabilities.Limit(10),
+			vulnerabilities.NamespacesFilter(),
+		)
+		assert.NoError(t, err)
+
+		all, err := client.ListCveSummaries(ctx, vulnerabilities.Limit(10))
+		assert.NoError(t, err)
+
+		assert.Equal(t, len(all.Nodes), len(withEmpty.Nodes))
 	})
 
 	t.Run("exclude namespaces reduces affected workloads", func(t *testing.T) {

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -357,6 +357,67 @@ func TestServer_ListWorkloadsForVulnerability_ExcludeNamespaces(t *testing.T) {
 	})
 }
 
+func TestServer_ListWorkloadsForVulnerability_NamespacesFilter(t *testing.T) {
+	cfg := testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1", "namespace-2", "namespace-3"},
+		workloadsPerNamespace: 1,
+		vulnsPerWorkload:      1,
+	}
+
+	ctx, db, _, client, cleanup := setupTest(t, cfg, true)
+	defer cleanup()
+
+	err := db.CreateImage(ctx, sql.CreateImageParams{
+		Name:     "image-1",
+		Tag:      "v1.0",
+		Metadata: map[string]string{},
+	})
+	require.NoError(t, err)
+
+	vulnResp, err := client.GetVulnerability(ctx,
+		"image-cluster-1-namespace-1-workload-1",
+		"v1.0",
+		"package-CWE-1-1",
+		"CWE-1-1",
+	)
+	require.NoError(t, err)
+	cveID := vulnResp.Vulnerability.Cve.Id
+	require.NotEmpty(t, cveID)
+
+	for _, ns := range []string{"namespace-2", "namespace-3"} {
+		_, err = client.GetVulnerability(ctx,
+			"image-cluster-1-"+ns+"-workload-1",
+			"v1.0",
+			"package-CWE-1-1",
+			"CWE-1-1",
+		)
+		require.NoError(t, err)
+	}
+
+	t.Run("only returns workloads in the specified namespaces", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx, vulnerabilities.VulnerabilityFilter{
+			CveIds: []string{cveID},
+		}, vulnerabilities.NamespacesFilter("namespace-1", "namespace-2"))
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.Len(t, resp.Nodes, 2)
+		namespaces := []string{resp.Nodes[0].WorkloadRef.Namespace, resp.Nodes[1].WorkloadRef.Namespace}
+		assert.ElementsMatch(t, []string{"namespace-1", "namespace-2"}, namespaces)
+	})
+
+	t.Run("returns all workloads when namespaces filter is empty", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx, vulnerabilities.VulnerabilityFilter{
+			CveIds: []string{cveID},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		require.Len(t, resp.Nodes, 3)
+	})
+}
+
 func TestServer_ListVulnerabilitiesForImage(t *testing.T) {
 	cfg := testSetupConfig{
 		clusters:              []string{"cluster-1"},

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2042,6 +2042,44 @@ func TestServer_ListCveSummaries(t *testing.T) {
 		assert.Equal(t, []string{"CVE-HIGH", "CVE-LOW", "CVE-ZERO"}, gotIDs)
 	})
 
+	t.Run("namespaces filter limits results to selected namespaces", func(t *testing.T) {
+		all, err := client.ListCveSummaries(ctx, vulnerabilities.Limit(10))
+		assert.NoError(t, err)
+		require.NotEmpty(t, all.Nodes)
+
+		allWorkloadsByID := make(map[string]int32)
+		for _, node := range all.Nodes {
+			allWorkloadsByID[node.Cve.Id] = node.AffectedWorkloads
+		}
+
+		filtered, err := client.ListCveSummaries(ctx,
+			vulnerabilities.Limit(10),
+			vulnerabilities.NamespacesFilter("namespace-1"),
+		)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, filtered.Nodes)
+
+		for _, node := range filtered.Nodes {
+			assert.NotNil(t, node.Cve)
+			assert.NotEmpty(t, node.Cve.Id)
+			assert.NotZero(t, node.AffectedWorkloads)
+			assert.LessOrEqual(t, node.AffectedWorkloads, allWorkloadsByID[node.Cve.Id])
+		}
+	})
+
+	t.Run("empty namespaces filter returns all results", func(t *testing.T) {
+		filtered, err := client.ListCveSummaries(ctx,
+			vulnerabilities.Limit(10),
+			vulnerabilities.NamespacesFilter("namespace-1"),
+		)
+		assert.NoError(t, err)
+
+		all, err := client.ListCveSummaries(ctx, vulnerabilities.Limit(10))
+		assert.NoError(t, err)
+
+		assert.GreaterOrEqual(t, len(all.Nodes), len(filtered.Nodes))
+	})
+
 	t.Run("exclude namespaces reduces affected workloads", func(t *testing.T) {
 		resp, err := client.ListCveSummaries(ctx,
 			vulnerabilities.Limit(10),

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -37,6 +37,7 @@ func (s *Server) ListVulnerabilitySummaries(ctx context.Context, request *vulner
 	summaries, err := s.querier.ListVulnerabilitySummaries(ctx, sql.ListVulnerabilitySummariesParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
+		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 		ImageName:     request.GetFilter().ImageName,
@@ -109,6 +110,7 @@ func (s *Server) GetVulnerabilitySummary(ctx context.Context, request *vulnerabi
 	row, err := s.querier.GetVulnerabilitySummary(ctx, sql.GetVulnerabilitySummaryParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
+		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 	})
@@ -161,6 +163,7 @@ func (s *Server) GetVulnerabilitySummaryTimeSeries(ctx context.Context, request 
 	timeSeries, err := s.querier.GetVulnerabilitySummaryTimeSeries(ctx, sql.GetVulnerabilitySummaryTimeSeriesParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
+		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 		Since:         since,
@@ -325,7 +328,7 @@ func (s *Server) ListCveSummaries(ctx context.Context, request *vulnerabilities.
 		ImageTag:          request.GetFilter().ImageTag,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
-		Namespaces:        request.GetFilter().GetNamespaces(),
+		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
 		IncludeSuppressed: request.IncludeSuppressed,
 		OrderBy:           SanitizeOrderBy(request.OrderBy, vulnerabilities.OrderByAffectedWorkloads),
 		Limit:             request.Limit,

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -1,3 +1,4 @@
+//lint:file-ignore SA1019 deprecated proto fields read intentionally for backwards compatibility
 package grpcvulnerabilities
 
 import (
@@ -312,15 +313,8 @@ func (s *Server) ListCveSummaries(ctx context.Context, request *vulnerabilities.
 		request.Filter = &vulnerabilities.Filter{}
 	}
 
-	excludeNamespaces := request.GetExcludeNamespaces()
-	if excludeNamespaces == nil {
-		excludeNamespaces = []string{}
-	}
-
-	excludeClusters := request.GetExcludeClusters()
-	if excludeClusters == nil {
-		excludeClusters = []string{}
-	}
+	excludeNamespaces := mergeStringSlices(request.GetFilter().GetExcludeNamespaces(), request.GetExcludeNamespaces())
+	excludeClusters := mergeStringSlices(request.GetFilter().GetExcludeClusters(), request.GetExcludeClusters())
 
 	cveSummaries, err := s.querier.ListCveSummaries(ctx, sql.ListCveSummariesParams{
 		Cluster:           request.GetFilter().Cluster,
@@ -331,6 +325,7 @@ func (s *Server) ListCveSummaries(ctx context.Context, request *vulnerabilities.
 		ImageTag:          request.GetFilter().ImageTag,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
+		Namespaces:        request.GetFilter().GetNamespaces(),
 		IncludeSuppressed: request.IncludeSuppressed,
 		OrderBy:           SanitizeOrderBy(request.OrderBy, vulnerabilities.OrderByAffectedWorkloads),
 		Limit:             request.Limit,

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -37,7 +37,7 @@ func (s *Server) ListVulnerabilitySummaries(ctx context.Context, request *vulner
 	summaries, err := s.querier.ListVulnerabilitySummaries(ctx, sql.ListVulnerabilitySummariesParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
-		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:    request.GetFilter().GetNamespaces(),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 		ImageName:     request.GetFilter().ImageName,
@@ -110,7 +110,7 @@ func (s *Server) GetVulnerabilitySummary(ctx context.Context, request *vulnerabi
 	row, err := s.querier.GetVulnerabilitySummary(ctx, sql.GetVulnerabilitySummaryParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
-		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:    request.GetFilter().GetNamespaces(),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 	})
@@ -163,7 +163,7 @@ func (s *Server) GetVulnerabilitySummaryTimeSeries(ctx context.Context, request 
 	timeSeries, err := s.querier.GetVulnerabilitySummaryTimeSeries(ctx, sql.GetVulnerabilitySummaryTimeSeriesParams{
 		Cluster:       request.GetFilter().Cluster,
 		Namespace:     request.GetFilter().Namespace,
-		Namespaces:    nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:    request.GetFilter().GetNamespaces(),
 		WorkloadTypes: request.Filter.GetWorkloadTypes(),
 		WorkloadName:  request.GetFilter().Workload,
 		Since:         since,
@@ -328,7 +328,7 @@ func (s *Server) ListCveSummaries(ctx context.Context, request *vulnerabilities.
 		ImageTag:          request.GetFilter().ImageTag,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
-		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:        request.GetFilter().GetNamespaces(),
 		IncludeSuppressed: request.IncludeSuppressed,
 		OrderBy:           SanitizeOrderBy(request.OrderBy, vulnerabilities.OrderByAffectedWorkloads),
 		Limit:             request.Limit,

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -39,6 +39,7 @@ func (s *Server) ListVulnerabilities(ctx context.Context, request *vulnerabiliti
 	v, err := s.querier.ListVulnerabilities(ctx, sql.ListVulnerabilitiesParams{
 		Cluster:           request.GetFilter().Cluster,
 		Namespace:         request.GetFilter().Namespace,
+		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
 		WorkloadType:      request.GetFilter().FuzzyWorkloadType(),
 		WorkloadName:      request.GetFilter().Workload,
 		ImageName:         request.GetFilter().ImageName,
@@ -99,6 +100,7 @@ func (s *Server) ListVulnerabilities(ctx context.Context, request *vulnerabiliti
 	total, err := s.querier.CountVulnerabilities(ctx, sql.CountVulnerabilitiesParams{
 		Cluster:           request.GetFilter().Cluster,
 		Namespace:         request.GetFilter().Namespace,
+		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
 		WorkloadType:      request.GetFilter().FuzzyWorkloadType(),
 		WorkloadName:      request.GetFilter().Workload,
 		IncludeSuppressed: request.IncludeSuppressed,
@@ -198,13 +200,14 @@ func (s *Server) ListSuppressedVulnerabilities(ctx context.Context, request *vul
 
 	filter := request.GetFilter()
 	suppressed, err := s.querier.ListSuppressedVulnerabilities(ctx, sql.ListSuppressedVulnerabilitiesParams{
-		Cluster:   filter.Cluster,
-		Namespace: filter.Namespace,
-		ImageName: filter.ImageName,
-		ImageTag:  filter.ImageTag,
-		Offset:    offset,
-		Limit:     limit,
-		OrderBy:   SanitizeOrderBy(request.OrderBy, vulnerabilities.OrderBySeverity),
+		Cluster:    filter.Cluster,
+		Namespace:  filter.Namespace,
+		Namespaces: nonNilStrings(filter.GetNamespaces()),
+		ImageName:  filter.ImageName,
+		ImageTag:   filter.ImageTag,
+		Offset:     offset,
+		Limit:      limit,
+		OrderBy:    SanitizeOrderBy(request.OrderBy, vulnerabilities.OrderBySeverity),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("list suppressed vulnerabilities: %w", err)
@@ -213,6 +216,7 @@ func (s *Server) ListSuppressedVulnerabilities(ctx context.Context, request *vul
 	total, err := s.querier.CountSuppressedVulnerabilities(ctx, sql.CountSuppressedVulnerabilitiesParams{
 		Cluster:      filter.Cluster,
 		Namespace:    filter.Namespace,
+		Namespaces:   nonNilStrings(filter.GetNamespaces()),
 		WorkloadType: filter.FuzzyWorkloadType(),
 		WorkloadName: filter.Workload,
 		ImageName:    filter.ImageName,
@@ -352,7 +356,7 @@ func (s *Server) ListWorkloadsForVulnerability(ctx context.Context, request *vul
 		CvssScore:         request.CvssScore,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
-		Namespaces:        filter.GetNamespaces(),
+		Namespaces:        nonNilStrings(filter.GetNamespaces()),
 		IncludeSuppressed: request.IncludeSuppressed,
 		Offset:            offset,
 		Limit:             limit,
@@ -586,6 +590,13 @@ func mergeStringSlices(a, b []string) []string {
 		}
 	}
 	return result
+}
+
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 // Users expect "asc" = weakest → strongest, so we flip direction here

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -1,3 +1,4 @@
+//lint:file-ignore SA1019 deprecated proto fields read intentionally for backwards compatibility
 package grpcvulnerabilities
 
 import (
@@ -331,15 +332,8 @@ func (s *Server) ListWorkloadsForVulnerability(ctx context.Context, request *vul
 		filter = &vulnerabilities.Filter{}
 	}
 
-	excludeNamespaces := request.GetExcludeNamespaces()
-	if excludeNamespaces == nil {
-		excludeNamespaces = []string{}
-	}
-
-	excludeClusters := request.GetExcludeClusters()
-	if excludeClusters == nil {
-		excludeClusters = []string{}
-	}
+	excludeNamespaces := mergeStringSlices(filter.GetExcludeNamespaces(), request.GetExcludeNamespaces())
+	excludeClusters := mergeStringSlices(filter.GetExcludeClusters(), request.GetExcludeClusters())
 
 	cveIDs := request.CveIds
 	if len(cveIDs) > 0 {
@@ -358,6 +352,7 @@ func (s *Server) ListWorkloadsForVulnerability(ctx context.Context, request *vul
 		CvssScore:         request.CvssScore,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
+		Namespaces:        filter.GetNamespaces(),
 		IncludeSuppressed: request.IncludeSuppressed,
 		Offset:            offset,
 		Limit:             limit,
@@ -581,6 +576,18 @@ func (s *Server) SuppressVulnerability(ctx context.Context, request *vulnerabili
 
 // SanitizeOrderBy
 // Special case: Severity is inverted (0 = Critical, 2 = Medium).
+func mergeStringSlices(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	result := make([]string, 0, len(a)+len(b))
+	for _, s := range append(a, b...) {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
 // Users expect "asc" = weakest → strongest, so we flip direction here
 // to make SQL ordering intuitive.
 func SanitizeOrderBy(orderBy *vulnerabilities.OrderBy, defaultOrder vulnerabilities.OrderByField) string {

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -39,7 +39,7 @@ func (s *Server) ListVulnerabilities(ctx context.Context, request *vulnerabiliti
 	v, err := s.querier.ListVulnerabilities(ctx, sql.ListVulnerabilitiesParams{
 		Cluster:           request.GetFilter().Cluster,
 		Namespace:         request.GetFilter().Namespace,
-		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:        request.GetFilter().GetNamespaces(),
 		WorkloadType:      request.GetFilter().FuzzyWorkloadType(),
 		WorkloadName:      request.GetFilter().Workload,
 		ImageName:         request.GetFilter().ImageName,
@@ -100,7 +100,7 @@ func (s *Server) ListVulnerabilities(ctx context.Context, request *vulnerabiliti
 	total, err := s.querier.CountVulnerabilities(ctx, sql.CountVulnerabilitiesParams{
 		Cluster:           request.GetFilter().Cluster,
 		Namespace:         request.GetFilter().Namespace,
-		Namespaces:        nonNilStrings(request.GetFilter().GetNamespaces()),
+		Namespaces:        request.GetFilter().GetNamespaces(),
 		WorkloadType:      request.GetFilter().FuzzyWorkloadType(),
 		WorkloadName:      request.GetFilter().Workload,
 		IncludeSuppressed: request.IncludeSuppressed,
@@ -202,7 +202,7 @@ func (s *Server) ListSuppressedVulnerabilities(ctx context.Context, request *vul
 	suppressed, err := s.querier.ListSuppressedVulnerabilities(ctx, sql.ListSuppressedVulnerabilitiesParams{
 		Cluster:    filter.Cluster,
 		Namespace:  filter.Namespace,
-		Namespaces: nonNilStrings(filter.GetNamespaces()),
+		Namespaces: filter.GetNamespaces(),
 		ImageName:  filter.ImageName,
 		ImageTag:   filter.ImageTag,
 		Offset:     offset,
@@ -216,7 +216,7 @@ func (s *Server) ListSuppressedVulnerabilities(ctx context.Context, request *vul
 	total, err := s.querier.CountSuppressedVulnerabilities(ctx, sql.CountSuppressedVulnerabilitiesParams{
 		Cluster:      filter.Cluster,
 		Namespace:    filter.Namespace,
-		Namespaces:   nonNilStrings(filter.GetNamespaces()),
+		Namespaces:   filter.GetNamespaces(),
 		WorkloadType: filter.FuzzyWorkloadType(),
 		WorkloadName: filter.Workload,
 		ImageName:    filter.ImageName,
@@ -356,7 +356,7 @@ func (s *Server) ListWorkloadsForVulnerability(ctx context.Context, request *vul
 		CvssScore:         request.CvssScore,
 		ExcludeClusters:   excludeClusters,
 		ExcludeNamespaces: excludeNamespaces,
-		Namespaces:        nonNilStrings(filter.GetNamespaces()),
+		Namespaces:        filter.GetNamespaces(),
 		IncludeSuppressed: request.IncludeSuppressed,
 		Offset:            offset,
 		Limit:             limit,
@@ -588,13 +588,6 @@ func mergeStringSlices(a, b []string) []string {
 		}
 	}
 	return result
-}
-
-func nonNilStrings(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }
 
 // Users expect "asc" = weakest → strongest, so we flip direction here

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -578,8 +578,6 @@ func (s *Server) SuppressVulnerability(ctx context.Context, request *vulnerabili
 	}, nil
 }
 
-// SanitizeOrderBy
-// Special case: Severity is inverted (0 = Critical, 2 = Medium).
 func mergeStringSlices(a, b []string) []string {
 	seen := make(map[string]struct{}, len(a)+len(b))
 	result := make([]string, 0, len(a)+len(b))

--- a/internal/database/queries/cve_summary.sql
+++ b/internal/database/queries/cve_summary.sql
@@ -17,8 +17,8 @@ WITH cve_data AS (
         OR w.namespace = sqlc.narg('namespace')::TEXT)
     AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
         OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
-    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+    AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+        OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL

--- a/internal/database/queries/cve_summary.sql
+++ b/internal/database/queries/cve_summary.sql
@@ -17,6 +17,8 @@ WITH cve_data AS (
         OR w.namespace = sqlc.narg('namespace')::TEXT)
     AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
         OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -401,8 +401,8 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+    OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('image_name')::TEXT IS NOT NULL THEN
         v.image_name = sqlc.narg('image_name')::TEXT
@@ -467,8 +467,8 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+    OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT
@@ -518,8 +518,8 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+    OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT
@@ -735,8 +735,8 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+    OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT
@@ -885,8 +885,8 @@ WHERE
         END)
     AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
         OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
-    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+    AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+        OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -877,6 +877,8 @@ WHERE
         END)
     AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
         OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -401,6 +401,8 @@ AND (
     ELSE
         TRUE
     END)
+AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('image_name')::TEXT IS NOT NULL THEN
         v.image_name = sqlc.narg('image_name')::TEXT
@@ -465,6 +467,8 @@ AND (
     ELSE
         TRUE
     END)
+AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT
@@ -514,6 +518,8 @@ AND (
     ELSE
         TRUE
     END)
+AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT
@@ -729,6 +735,8 @@ AND (
     ELSE
         TRUE
     END)
+AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+    OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
 AND (
     CASE WHEN sqlc.narg('workload_type')::TEXT IS NOT NULL THEN
         w.workload_type = sqlc.narg('workload_type')::TEXT

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -59,6 +59,8 @@ WITH filtered_workloads AS (
         OR w.cluster = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR w.namespace = sqlc.narg('namespace')::TEXT)
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL
@@ -192,6 +194,8 @@ WITH filtered_workloads AS (
         OR w.cluster = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR w.namespace = sqlc.narg('namespace')::TEXT)
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL
@@ -233,6 +237,8 @@ WHERE
         OR CLUSTER = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR namespace = sqlc.narg('namespace')::TEXT)
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -59,8 +59,8 @@ WITH filtered_workloads AS (
         OR w.cluster = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR w.namespace = sqlc.narg('namespace')::TEXT)
-    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+    AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+        OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL
@@ -194,8 +194,8 @@ WITH filtered_workloads AS (
         OR w.cluster = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR w.namespace = sqlc.narg('namespace')::TEXT)
-    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+    AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+        OR w.namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR w.workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL
@@ -237,8 +237,8 @@ WHERE
         OR CLUSTER = sqlc.narg('cluster')::TEXT)
     AND (sqlc.narg('namespace')::TEXT IS NULL
         OR namespace = sqlc.narg('namespace')::TEXT)
-    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
-        OR namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
+    AND (COALESCE(cardinality(sqlc.narg('namespaces')::TEXT[]), 0) = 0
+        OR namespace = ANY (sqlc.narg('namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL
         OR workload_type = ANY (sqlc.narg('workload_types')::TEXT[]))
     AND (sqlc.narg('workload_name')::TEXT IS NULL

--- a/internal/database/sql/cve_summary.sql.go
+++ b/internal/database/sql/cve_summary.sql.go
@@ -28,17 +28,19 @@ WITH cve_data AS (
         OR w.namespace = $5::TEXT)
     AND (cardinality($6::TEXT[]) = 0
         OR w.namespace <> ALL ($6::TEXT[]))
-    AND ($7::TEXT[] IS NULL
-        OR w.workload_type = ANY ($7::TEXT[]))
-    AND ($8::TEXT IS NULL
-        OR w.name = $8::TEXT)
+    AND (cardinality($7::TEXT[]) = 0
+        OR w.namespace = ANY ($7::TEXT[]))
+    AND ($8::TEXT[] IS NULL
+        OR w.workload_type = ANY ($8::TEXT[]))
     AND ($9::TEXT IS NULL
-        OR v.image_name = $9::TEXT)
+        OR w.name = $9::TEXT)
     AND ($10::TEXT IS NULL
-        OR v.image_tag = $10::TEXT)
-    AND (cardinality($11::TEXT[]) = 0
-        OR w.cluster <> ALL ($11::TEXT[]))
-    AND ($12::BOOLEAN IS TRUE
+        OR v.image_name = $10::TEXT)
+    AND ($11::TEXT IS NULL
+        OR v.image_tag = $11::TEXT)
+    AND (cardinality($12::TEXT[]) = 0
+        OR w.cluster <> ALL ($12::TEXT[]))
+    AND ($13::BOOLEAN IS TRUE
         OR COALESCE(sv.suppressed, FALSE) = FALSE)
 GROUP BY
     c.cve_id
@@ -98,6 +100,7 @@ type ListCveSummariesParams struct {
 	Cluster           *string
 	Namespace         *string
 	ExcludeNamespaces []string
+	Namespaces        []string
 	WorkloadTypes     []string
 	WorkloadName      *string
 	ImageName         *string
@@ -132,6 +135,7 @@ func (q *Queries) ListCveSummaries(ctx context.Context, arg ListCveSummariesPara
 		arg.Cluster,
 		arg.Namespace,
 		arg.ExcludeNamespaces,
+		arg.Namespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,
 		arg.ImageName,

--- a/internal/database/sql/cve_summary.sql.go
+++ b/internal/database/sql/cve_summary.sql.go
@@ -28,7 +28,7 @@ WITH cve_data AS (
         OR w.namespace = $5::TEXT)
     AND (cardinality($6::TEXT[]) = 0
         OR w.namespace <> ALL ($6::TEXT[]))
-    AND (cardinality($7::TEXT[]) = 0
+    AND (COALESCE(cardinality($7::TEXT[]), 0) = 0
         OR w.namespace = ANY ($7::TEXT[]))
     AND ($8::TEXT[] IS NULL
         OR w.workload_type = ANY ($8::TEXT[]))

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -33,7 +33,7 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality($3::TEXT[]) = 0
+AND (COALESCE(cardinality($3::TEXT[]), 0) = 0
     OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
@@ -110,7 +110,7 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality($3::TEXT[]) = 0
+AND (COALESCE(cardinality($3::TEXT[]), 0) = 0
     OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
@@ -599,7 +599,7 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality($3::TEXT[]) = 0
+AND (COALESCE(cardinality($3::TEXT[]), 0) = 0
     OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
@@ -858,7 +858,7 @@ AND (
     ELSE
         TRUE
     END)
-AND (cardinality($3::TEXT[]) = 0
+AND (COALESCE(cardinality($3::TEXT[]), 0) = 0
     OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
@@ -1357,7 +1357,7 @@ WHERE
         END)
     AND (cardinality($6::TEXT[]) = 0
         OR w.namespace <> ALL ($6::TEXT[]))
-    AND (cardinality($7::TEXT[]) = 0
+    AND (COALESCE(cardinality($7::TEXT[]), 0) = 0
         OR w.namespace = ANY ($7::TEXT[]))
     AND ($8::TEXT[] IS NULL
         OR w.workload_type = ANY ($8::TEXT[]))

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -1341,30 +1341,32 @@ WHERE
         END)
     AND (cardinality($6::TEXT[]) = 0
         OR w.namespace <> ALL ($6::TEXT[]))
-    AND ($7::TEXT[] IS NULL
-        OR w.workload_type = ANY ($7::TEXT[]))
-    AND (
-        CASE WHEN $8::TEXT IS NOT NULL THEN
-            w.name = $8::TEXT
-        ELSE
-            TRUE
-        END)
+    AND (cardinality($7::TEXT[]) = 0
+        OR w.namespace = ANY ($7::TEXT[]))
+    AND ($8::TEXT[] IS NULL
+        OR w.workload_type = ANY ($8::TEXT[]))
     AND (
         CASE WHEN $9::TEXT IS NOT NULL THEN
-            v.image_name = $9::TEXT
+            w.name = $9::TEXT
         ELSE
             TRUE
         END)
     AND (
         CASE WHEN $10::TEXT IS NOT NULL THEN
-            v.image_tag = $10::TEXT
+            v.image_name = $10::TEXT
         ELSE
             TRUE
         END)
-    AND ($11::BOOLEAN IS TRUE
+    AND (
+        CASE WHEN $11::TEXT IS NOT NULL THEN
+            v.image_tag = $11::TEXT
+        ELSE
+            TRUE
+        END)
+    AND ($12::BOOLEAN IS TRUE
         OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
-    CASE WHEN $12 = 'cvss_score_desc' THEN
+    CASE WHEN $13 = 'cvss_score_desc' THEN
         CASE WHEN c.cvss_score = 0
             OR c.cvss_score IS NULL THEN
             1
@@ -1372,39 +1374,39 @@ ORDER BY
             0
         END
     END ASC,
-    CASE WHEN $12 = 'cvss_score_desc' THEN
+    CASE WHEN $13 = 'cvss_score_desc' THEN
         c.cvss_score
     END DESC,
-    CASE WHEN $12 = 'cvss_score_asc' THEN
+    CASE WHEN $13 = 'cvss_score_asc' THEN
         c.cvss_score
     END ASC,
-    CASE WHEN $12 = 'cve_id_desc' THEN
+    CASE WHEN $13 = 'cve_id_desc' THEN
         v.cve_id
     END DESC,
-    CASE WHEN $12 = 'cve_id_asc' THEN
+    CASE WHEN $13 = 'cve_id_asc' THEN
         v.cve_id
     END ASC,
-    CASE WHEN $12 = 'workload_asc' THEN
+    CASE WHEN $13 = 'workload_asc' THEN
         w.name
     END ASC,
-    CASE WHEN $12 = 'workload_desc' THEN
+    CASE WHEN $13 = 'workload_desc' THEN
         w.name
     END DESC,
-    CASE WHEN $12 = 'namespace_asc' THEN
+    CASE WHEN $13 = 'namespace_asc' THEN
         w.namespace
     END ASC,
-    CASE WHEN $12 = 'namespace_desc' THEN
+    CASE WHEN $13 = 'namespace_desc' THEN
         w.namespace
     END DESC,
-    CASE WHEN $12 = 'cluster_asc' THEN
+    CASE WHEN $13 = 'cluster_asc' THEN
         w.cluster
     END ASC,
-    CASE WHEN $12 = 'cluster_desc' THEN
+    CASE WHEN $13 = 'cluster_desc' THEN
         w.cluster
     END DESC,
     v.id ASC
-LIMIT $14
-OFFSET $13
+LIMIT $15
+OFFSET $14
 `
 
 type ListWorkloadsForVulnerabilitiesParams struct {
@@ -1414,6 +1416,7 @@ type ListWorkloadsForVulnerabilitiesParams struct {
 	ExcludeClusters   []string
 	Namespace         *string
 	ExcludeNamespaces []string
+	Namespaces        []string
 	WorkloadTypes     []string
 	WorkloadName      *string
 	ImageName         *string
@@ -1467,6 +1470,7 @@ func (q *Queries) ListWorkloadsForVulnerabilities(ctx context.Context, arg ListW
 		arg.ExcludeClusters,
 		arg.Namespace,
 		arg.ExcludeNamespaces,
+		arg.Namespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,
 		arg.ImageName,

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -33,27 +33,29 @@ AND (
     ELSE
         TRUE
     END)
-AND (
-    CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.workload_type = $3::TEXT
-    ELSE
-        TRUE
-    END)
+AND (cardinality($3::TEXT[]) = 0
+    OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
-        w.name = $4::TEXT
+        w.workload_type = $4::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $5::TEXT IS NOT NULL THEN
-        v.image_name = $5::TEXT
+        w.name = $5::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $6::TEXT IS NOT NULL THEN
-        v.image_tag = $6::TEXT
+        v.image_name = $6::TEXT
+    ELSE
+        TRUE
+    END)
+AND (
+    CASE WHEN $7::TEXT IS NOT NULL THEN
+        v.image_tag = $7::TEXT
     ELSE
         TRUE
     END)
@@ -62,6 +64,7 @@ AND (
 type CountSuppressedVulnerabilitiesParams struct {
 	Cluster      *string
 	Namespace    *string
+	Namespaces   []string
 	WorkloadType *string
 	WorkloadName *string
 	ImageName    *string
@@ -72,6 +75,7 @@ func (q *Queries) CountSuppressedVulnerabilities(ctx context.Context, arg CountS
 	row := q.db.QueryRow(ctx, countSuppressedVulnerabilities,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadType,
 		arg.WorkloadName,
 		arg.ImageName,
@@ -106,25 +110,28 @@ AND (
     ELSE
         TRUE
     END)
-AND (
-    CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.workload_type = $3::TEXT
-    ELSE
-        TRUE
-    END)
+AND (cardinality($3::TEXT[]) = 0
+    OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
-        w.name = $4::TEXT
+        w.workload_type = $4::TEXT
     ELSE
         TRUE
     END)
-AND ($5::BOOLEAN IS TRUE
+AND (
+    CASE WHEN $5::TEXT IS NOT NULL THEN
+        w.name = $5::TEXT
+    ELSE
+        TRUE
+    END)
+AND ($6::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 `
 
 type CountVulnerabilitiesParams struct {
 	Cluster           *string
 	Namespace         *string
+	Namespaces        []string
 	WorkloadType      *string
 	WorkloadName      *string
 	IncludeSuppressed *bool
@@ -134,6 +141,7 @@ func (q *Queries) CountVulnerabilities(ctx context.Context, arg CountVulnerabili
 	row := q.db.QueryRow(ctx, countVulnerabilities,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadType,
 		arg.WorkloadName,
 		arg.IncludeSuppressed,
@@ -591,56 +599,59 @@ AND (
     ELSE
         TRUE
     END)
+AND (cardinality($3::TEXT[]) = 0
+    OR w.namespace = ANY ($3::TEXT[]))
 AND (
-    CASE WHEN $3::TEXT IS NOT NULL THEN
-        v.image_name = $3::TEXT
+    CASE WHEN $4::TEXT IS NOT NULL THEN
+        v.image_name = $4::TEXT
     ELSE
         TRUE
     END)
 AND (
-    CASE WHEN $4::TEXT IS NOT NULL THEN
-        v.image_tag = $4::TEXT
+    CASE WHEN $5::TEXT IS NOT NULL THEN
+        v.image_tag = $5::TEXT
     ELSE
         TRUE
     END)
 ORDER BY
-    CASE WHEN $5 = 'severity_asc' THEN
+    CASE WHEN $6 = 'severity_asc' THEN
         c.severity
     END ASC,
-    CASE WHEN $5 = 'severity_desc' THEN
+    CASE WHEN $6 = 'severity_desc' THEN
         c.severity
     END DESC,
-    CASE WHEN $5 = 'workload_asc' THEN
+    CASE WHEN $6 = 'workload_asc' THEN
         w.name
     END ASC,
-    CASE WHEN $5 = 'workload_desc' THEN
+    CASE WHEN $6 = 'workload_desc' THEN
         w.name
     END DESC,
-    CASE WHEN $5 = 'namespace_asc' THEN
+    CASE WHEN $6 = 'namespace_asc' THEN
         w.namespace
     END ASC,
-    CASE WHEN $5 = 'namespace_desc' THEN
+    CASE WHEN $6 = 'namespace_desc' THEN
         w.namespace
     END DESC,
-    CASE WHEN $5 = 'cluster_asc' THEN
+    CASE WHEN $6 = 'cluster_asc' THEN
         w.cluster
     END ASC,
-    CASE WHEN $5 = 'cluster_desc' THEN
+    CASE WHEN $6 = 'cluster_desc' THEN
         w.cluster
     END DESC,
     v.id ASC
-LIMIT $7
-OFFSET $6
+LIMIT $8
+OFFSET $7
 `
 
 type ListSuppressedVulnerabilitiesParams struct {
-	Cluster   *string
-	Namespace *string
-	ImageName *string
-	ImageTag  *string
-	OrderBy   interface{}
-	Offset    int32
-	Limit     int32
+	Cluster    *string
+	Namespace  *string
+	Namespaces []string
+	ImageName  *string
+	ImageTag   *string
+	OrderBy    interface{}
+	Offset     int32
+	Limit      int32
 }
 
 type ListSuppressedVulnerabilitiesRow struct {
@@ -688,6 +699,7 @@ func (q *Queries) ListSuppressedVulnerabilities(ctx context.Context, arg ListSup
 	rows, err := q.db.Query(ctx, listSuppressedVulnerabilities,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.ImageName,
 		arg.ImageTag,
 		arg.OrderBy,
@@ -846,77 +858,80 @@ AND (
     ELSE
         TRUE
     END)
-AND (
-    CASE WHEN $3::TEXT IS NOT NULL THEN
-        w.workload_type = $3::TEXT
-    ELSE
-        TRUE
-    END)
+AND (cardinality($3::TEXT[]) = 0
+    OR w.namespace = ANY ($3::TEXT[]))
 AND (
     CASE WHEN $4::TEXT IS NOT NULL THEN
-        w.name = $4::TEXT
+        w.workload_type = $4::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $5::TEXT IS NOT NULL THEN
-        v.image_name = $5::TEXT
+        w.name = $5::TEXT
     ELSE
         TRUE
     END)
 AND (
     CASE WHEN $6::TEXT IS NOT NULL THEN
-        v.image_tag = $6::TEXT
+        v.image_name = $6::TEXT
     ELSE
         TRUE
     END)
-AND ($7::BOOLEAN IS TRUE
+AND (
+    CASE WHEN $7::TEXT IS NOT NULL THEN
+        v.image_tag = $7::TEXT
+    ELSE
+        TRUE
+    END)
+AND ($8::BOOLEAN IS TRUE
     OR COALESCE(sv.suppressed, FALSE) = FALSE)
 ORDER BY
-    CASE WHEN $8 = 'severity_asc' THEN
+    CASE WHEN $9 = 'severity_asc' THEN
         c.severity
     END ASC,
-    CASE WHEN $8 = 'severity_desc' THEN
+    CASE WHEN $9 = 'severity_desc' THEN
         c.severity
     END DESC,
-    CASE WHEN $8 = 'workload_asc' THEN
+    CASE WHEN $9 = 'workload_asc' THEN
         w.name
     END ASC,
-    CASE WHEN $8 = 'workload_desc' THEN
+    CASE WHEN $9 = 'workload_desc' THEN
         w.name
     END DESC,
-    CASE WHEN $8 = 'namespace_asc' THEN
+    CASE WHEN $9 = 'namespace_asc' THEN
         w.namespace
     END ASC,
-    CASE WHEN $8 = 'namespace_desc' THEN
+    CASE WHEN $9 = 'namespace_desc' THEN
         w.namespace
     END DESC,
-    CASE WHEN $8 = 'cluster_asc' THEN
+    CASE WHEN $9 = 'cluster_asc' THEN
         w.cluster
     END ASC,
-    CASE WHEN $8 = 'cluster_desc' THEN
+    CASE WHEN $9 = 'cluster_desc' THEN
         w.cluster
     END DESC,
-    CASE WHEN $8 = 'created_at_asc' THEN
+    CASE WHEN $9 = 'created_at_asc' THEN
         v.created_at
     END ASC,
-    CASE WHEN $8 = 'created_at_desc' THEN
+    CASE WHEN $9 = 'created_at_desc' THEN
         v.created_at
     END DESC,
-    CASE WHEN $8 = 'updated_at_asc' THEN
+    CASE WHEN $9 = 'updated_at_asc' THEN
         v.updated_at
     END ASC,
-    CASE WHEN $8 = 'updated_at_desc' THEN
+    CASE WHEN $9 = 'updated_at_desc' THEN
         v.updated_at
     END DESC,
     v.id ASC
-LIMIT $10
-OFFSET $9
+LIMIT $11
+OFFSET $10
 `
 
 type ListVulnerabilitiesParams struct {
 	Cluster           *string
 	Namespace         *string
+	Namespaces        []string
 	WorkloadType      *string
 	WorkloadName      *string
 	ImageName         *string
@@ -964,6 +979,7 @@ func (q *Queries) ListVulnerabilities(ctx context.Context, arg ListVulnerabiliti
 	rows, err := q.db.Query(ctx, listVulnerabilities,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadType,
 		arg.WorkloadName,
 		arg.ImageName,

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -134,7 +134,7 @@ WITH filtered_workloads AS (
         OR w.cluster = $1::TEXT)
     AND ($2::TEXT IS NULL
         OR w.namespace = $2::TEXT)
-    AND (cardinality($3::TEXT[]) = 0
+    AND (COALESCE(cardinality($3::TEXT[]), 0) = 0
         OR w.namespace = ANY ($3::TEXT[]))
     AND ($4::TEXT[] IS NULL
         OR w.workload_type = ANY ($4::TEXT[]))
@@ -255,7 +255,7 @@ WHERE
         OR CLUSTER = $2::TEXT)
     AND ($3::TEXT IS NULL
         OR namespace = $3::TEXT)
-    AND (cardinality($4::TEXT[]) = 0
+    AND (COALESCE(cardinality($4::TEXT[]), 0) = 0
         OR namespace = ANY ($4::TEXT[]))
     AND ($5::TEXT[] IS NULL
         OR workload_type = ANY ($5::TEXT[]))
@@ -415,7 +415,7 @@ WITH filtered_workloads AS (
         OR w.cluster = $4::TEXT)
     AND ($5::TEXT IS NULL
         OR w.namespace = $5::TEXT)
-    AND (cardinality($6::TEXT[]) = 0
+    AND (COALESCE(cardinality($6::TEXT[]), 0) = 0
         OR w.namespace = ANY ($6::TEXT[]))
     AND ($7::TEXT[] IS NULL
         OR w.workload_type = ANY ($7::TEXT[]))

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -134,10 +134,12 @@ WITH filtered_workloads AS (
         OR w.cluster = $1::TEXT)
     AND ($2::TEXT IS NULL
         OR w.namespace = $2::TEXT)
-    AND ($3::TEXT[] IS NULL
-        OR w.workload_type = ANY ($3::TEXT[]))
-    AND ($4::TEXT IS NULL
-        OR w.name = $4::TEXT))
+    AND (cardinality($3::TEXT[]) = 0
+        OR w.namespace = ANY ($3::TEXT[]))
+    AND ($4::TEXT[] IS NULL
+        OR w.workload_type = ANY ($4::TEXT[]))
+    AND ($5::TEXT IS NULL
+        OR w.name = $5::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
     CAST(COUNT(DISTINCT CASE WHEN v.image_name IS NOT NULL THEN
@@ -159,6 +161,7 @@ FROM
 type GetVulnerabilitySummaryParams struct {
 	Cluster       *string
 	Namespace     *string
+	Namespaces    []string
 	WorkloadTypes []string
 	WorkloadName  *string
 }
@@ -179,6 +182,7 @@ func (q *Queries) GetVulnerabilitySummary(ctx context.Context, arg GetVulnerabil
 	row := q.db.QueryRow(ctx, getVulnerabilitySummary,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,
 	)
@@ -251,10 +255,12 @@ WHERE
         OR CLUSTER = $2::TEXT)
     AND ($3::TEXT IS NULL
         OR namespace = $3::TEXT)
-    AND ($4::TEXT[] IS NULL
-        OR workload_type = ANY ($4::TEXT[]))
-    AND ($5::TEXT IS NULL
-        OR workload_name = $5::TEXT)
+    AND (cardinality($4::TEXT[]) = 0
+        OR namespace = ANY ($4::TEXT[]))
+    AND ($5::TEXT[] IS NULL
+        OR workload_type = ANY ($5::TEXT[]))
+    AND ($6::TEXT IS NULL
+        OR workload_name = $6::TEXT)
 GROUP BY
     snapshot_date
 ORDER BY
@@ -265,6 +271,7 @@ type GetVulnerabilitySummaryTimeSeriesParams struct {
 	Since         pgtype.Timestamptz
 	Cluster       *string
 	Namespace     *string
+	Namespaces    []string
 	WorkloadTypes []string
 	WorkloadName  *string
 }
@@ -286,6 +293,7 @@ func (q *Queries) GetVulnerabilitySummaryTimeSeries(ctx context.Context, arg Get
 		arg.Since,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,
 	)
@@ -407,10 +415,12 @@ WITH filtered_workloads AS (
         OR w.cluster = $4::TEXT)
     AND ($5::TEXT IS NULL
         OR w.namespace = $5::TEXT)
-    AND ($6::TEXT[] IS NULL
-        OR w.workload_type = ANY ($6::TEXT[]))
-    AND ($7::TEXT IS NULL
-        OR w.name = $7::TEXT)
+    AND (cardinality($6::TEXT[]) = 0
+        OR w.namespace = ANY ($6::TEXT[]))
+    AND ($7::TEXT[] IS NULL
+        OR w.workload_type = ANY ($7::TEXT[]))
+    AND ($8::TEXT IS NULL
+        OR w.name = $8::TEXT)
 ),
 vulnerability_data AS (
     SELECT
@@ -446,19 +456,19 @@ vulnerability_data AS (
         LEFT JOIN vulnerability_summary v ON w.image_name = v.image_name
             AND (
                 -- If no since join on image_tag, if since is set ignore image_tag
-                CASE WHEN $8::TIMESTAMP WITH TIME ZONE IS NULL THEN
+                CASE WHEN $9::TIMESTAMP WITH TIME ZONE IS NULL THEN
                     w.image_tag = v.image_tag
                 ELSE
                     TRUE
                 END)
         LEFT JOIN images i ON i.name = w.image_name
             AND i.tag = w.image_tag
-    WHERE ($9::TEXT IS NULL
-        OR v.image_name = $9::TEXT)
-    AND ($10::TEXT IS NULL
-        OR v.image_tag = $10::TEXT)
-    AND ($8::TIMESTAMP WITH TIME ZONE IS NULL
-        OR v.updated_at > $8::TIMESTAMP WITH TIME ZONE))
+    WHERE ($10::TEXT IS NULL
+        OR v.image_name = $10::TEXT)
+    AND ($11::TEXT IS NULL
+        OR v.image_tag = $11::TEXT)
+    AND ($9::TIMESTAMP WITH TIME ZONE IS NULL
+        OR v.updated_at > $9::TIMESTAMP WITH TIME ZONE))
 SELECT
     id, workload_name, workload_type, namespace, cluster, current_image_name, current_image_tag, image_name, image_tag, critical, high, medium, low, unassigned, risk_score, workload_created_at, workload_updated_at, summary_created_at, summary_updated_at, has_sbom, workload_state, image_state, sbom_processing_started_at,
 (
@@ -535,6 +545,7 @@ type ListVulnerabilitySummariesParams struct {
 	Limit         int32
 	Cluster       *string
 	Namespace     *string
+	Namespaces    []string
 	WorkloadTypes []string
 	WorkloadName  *string
 	Since         pgtype.Timestamptz
@@ -576,6 +587,7 @@ func (q *Queries) ListVulnerabilitySummaries(ctx context.Context, arg ListVulner
 		arg.Limit,
 		arg.Cluster,
 		arg.Namespace,
+		arg.Namespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,
 		arg.Since,

--- a/pkg/api/vulnerabilities/options.go
+++ b/pkg/api/vulnerabilities/options.go
@@ -307,7 +307,10 @@ func applyOptions(opts ...Option) *Options {
 		o.Filter.ExcludeClusters = nil
 	}
 
-	// Keep deprecated fields in sync so existing consumers (e.g. nais/api) still see them
+	// Keep deprecated fields in sync so client.go can still populate the request-level
+	// ExcludeNamespaces/ExcludeClusters proto fields on the wire.
+	// TODO: once the deprecated request-level fields are removed from the proto and client.go
+	// stops setting them, delete these two lines and the Options.ExcludeNamespaces/ExcludeClusters fields.
 	o.ExcludeNamespaces = o.Filter.ExcludeNamespaces
 	o.ExcludeClusters = o.Filter.ExcludeClusters
 

--- a/pkg/api/vulnerabilities/options.go
+++ b/pkg/api/vulnerabilities/options.go
@@ -91,8 +91,8 @@ type Options struct {
 	Since             *timestamppb.Timestamp
 	SinceType         *SinceType
 	Severity          *Severity
-	ExcludeNamespaces []string
-	ExcludeClusters   []string
+	ExcludeNamespaces []string // Deprecated: use Filter.ExcludeNamespaces via ExcludeNamespacesFilter
+	ExcludeClusters   []string // Deprecated: use Filter.ExcludeClusters via ExcludeClustersFilter
 }
 
 type VulnerabilityFilter struct {
@@ -172,6 +172,15 @@ func NamespaceFilter(name string) Option {
 			o.Filter = &Filter{}
 		}
 		o.Filter.Namespace = &name
+	})
+}
+
+func NamespacesFilter(names ...string) Option {
+	return newFuncOption(func(o *Options) {
+		if o.Filter == nil {
+			o.Filter = &Filter{}
+		}
+		o.Filter.Namespaces = append(o.Filter.Namespaces, names...)
 	})
 }
 
@@ -257,13 +266,19 @@ func SeverityFilter(sev Severity) Option {
 
 func ExcludeNamespacesFilter(namespace ...string) Option {
 	return newFuncOption(func(o *Options) {
-		o.ExcludeNamespaces = append(o.ExcludeNamespaces, namespace...)
+		if o.Filter == nil {
+			o.Filter = &Filter{}
+		}
+		o.Filter.ExcludeNamespaces = append(o.Filter.ExcludeNamespaces, namespace...)
 	})
 }
 
 func ExcludeClustersFilter(cluster ...string) Option {
 	return newFuncOption(func(o *Options) {
-		o.ExcludeClusters = append(o.ExcludeClusters, cluster...)
+		if o.Filter == nil {
+			o.Filter = &Filter{}
+		}
+		o.Filter.ExcludeClusters = append(o.Filter.ExcludeClusters, cluster...)
 	})
 }
 
@@ -279,14 +294,22 @@ func applyOptions(opts ...Option) *Options {
 		o.Limit = DefaultLimit
 	}
 
-	// If single-namespace include is set, exclude list is irrelevant
+	// Merge deprecated Options-level fields into Filter for backwards compat
+	o.Filter.ExcludeNamespaces = append(o.Filter.ExcludeNamespaces, o.ExcludeNamespaces...)
+	o.Filter.ExcludeClusters = append(o.Filter.ExcludeClusters, o.ExcludeClusters...)
+
+	// If single-namespace/cluster include is set, exclude lists are irrelevant
 	if o.Filter.Namespace != nil {
-		o.ExcludeNamespaces = nil
+		o.Filter.ExcludeNamespaces = nil
 	}
 
 	if o.Filter.Cluster != nil {
-		o.ExcludeClusters = nil
+		o.Filter.ExcludeClusters = nil
 	}
+
+	// Keep deprecated fields in sync so existing consumers (e.g. nais/api) still see them
+	o.ExcludeNamespaces = o.Filter.ExcludeNamespaces
+	o.ExcludeClusters = o.Filter.ExcludeClusters
 
 	return o
 }

--- a/pkg/api/vulnerabilities/schemas/vulnerabilities.proto
+++ b/pkg/api/vulnerabilities/schemas/vulnerabilities.proto
@@ -54,11 +54,14 @@ enum SbomStatus {
 
 message Filter {
   optional string cluster = 1;
-  optional string namespace = 2;
+  optional string namespace = 2 [deprecated = true]; // use namespaces instead
   optional string workload = 3;
   optional string workload_type = 4;
   optional string image_name = 5;
   optional string image_tag = 6;
+  repeated string namespaces = 7;
+  repeated string exclude_namespaces = 8;
+  repeated string exclude_clusters = 9;
 }
 
 message OrderBy {
@@ -285,8 +288,8 @@ message ListWorkloadsForVulnerabilityRequest {
   int32 limit = 4;
   int32 offset = 5;
   optional OrderBy order_by = 6;
-  repeated string exclude_namespaces = 7;
-  repeated string  exclude_clusters = 8;
+  repeated string exclude_namespaces = 7 [deprecated = true]; // use filter.exclude_namespaces instead
+  repeated string exclude_clusters = 8 [deprecated = true];   // use filter.exclude_clusters instead
   optional bool include_suppressed = 9;
 }
 
@@ -305,8 +308,8 @@ message ListCveSummariesRequest {
   int32 limit = 2;
   int32 offset = 3;
   optional OrderBy order_by = 4;
-  repeated string exclude_namespaces = 5;
-  repeated string  exclude_clusters = 6;
+  repeated string exclude_namespaces = 5 [deprecated = true]; // use filter.exclude_namespaces instead
+  repeated string exclude_clusters = 6 [deprecated = true];   // use filter.exclude_clusters instead
   optional bool include_suppressed = 7;
 }
 

--- a/pkg/api/vulnerabilities/vulnerabilities.pb.go
+++ b/pkg/api/vulnerabilities/vulnerabilities.pb.go
@@ -285,15 +285,19 @@ func (SbomStatus) EnumDescriptor() ([]byte, []int) {
 }
 
 type Filter struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Cluster       *string                `protobuf:"bytes,1,opt,name=cluster,proto3,oneof" json:"cluster,omitempty"`
-	Namespace     *string                `protobuf:"bytes,2,opt,name=namespace,proto3,oneof" json:"namespace,omitempty"`
-	Workload      *string                `protobuf:"bytes,3,opt,name=workload,proto3,oneof" json:"workload,omitempty"`
-	WorkloadType  *string                `protobuf:"bytes,4,opt,name=workload_type,json=workloadType,proto3,oneof" json:"workload_type,omitempty"`
-	ImageName     *string                `protobuf:"bytes,5,opt,name=image_name,json=imageName,proto3,oneof" json:"image_name,omitempty"`
-	ImageTag      *string                `protobuf:"bytes,6,opt,name=image_tag,json=imageTag,proto3,oneof" json:"image_tag,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Cluster *string                `protobuf:"bytes,1,opt,name=cluster,proto3,oneof" json:"cluster,omitempty"`
+	// Deprecated: Marked as deprecated in vulnerabilities.proto.
+	Namespace         *string  `protobuf:"bytes,2,opt,name=namespace,proto3,oneof" json:"namespace,omitempty"` // use namespaces instead
+	Workload          *string  `protobuf:"bytes,3,opt,name=workload,proto3,oneof" json:"workload,omitempty"`
+	WorkloadType      *string  `protobuf:"bytes,4,opt,name=workload_type,json=workloadType,proto3,oneof" json:"workload_type,omitempty"`
+	ImageName         *string  `protobuf:"bytes,5,opt,name=image_name,json=imageName,proto3,oneof" json:"image_name,omitempty"`
+	ImageTag          *string  `protobuf:"bytes,6,opt,name=image_tag,json=imageTag,proto3,oneof" json:"image_tag,omitempty"`
+	Namespaces        []string `protobuf:"bytes,7,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
+	ExcludeNamespaces []string `protobuf:"bytes,8,rep,name=exclude_namespaces,json=excludeNamespaces,proto3" json:"exclude_namespaces,omitempty"`
+	ExcludeClusters   []string `protobuf:"bytes,9,rep,name=exclude_clusters,json=excludeClusters,proto3" json:"exclude_clusters,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *Filter) Reset() {
@@ -333,6 +337,7 @@ func (x *Filter) GetCluster() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in vulnerabilities.proto.
 func (x *Filter) GetNamespace() string {
 	if x != nil && x.Namespace != nil {
 		return *x.Namespace
@@ -366,6 +371,27 @@ func (x *Filter) GetImageTag() string {
 		return *x.ImageTag
 	}
 	return ""
+}
+
+func (x *Filter) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
+}
+
+func (x *Filter) GetExcludeNamespaces() []string {
+	if x != nil {
+		return x.ExcludeNamespaces
+	}
+	return nil
+}
+
+func (x *Filter) GetExcludeClusters() []string {
+	if x != nil {
+		return x.ExcludeClusters
+	}
+	return nil
 }
 
 type OrderBy struct {
@@ -2415,16 +2441,18 @@ func (x *ListWorkloadsForVulnerabilityByIdResponse) GetWorkloadRef() []*Workload
 }
 
 type ListWorkloadsForVulnerabilityRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Filter            *Filter                `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
-	CveIds            []string               `protobuf:"bytes,2,rep,name=cve_ids,json=cveIds,proto3" json:"cve_ids,omitempty"`
-	CvssScore         *float64               `protobuf:"fixed64,3,opt,name=cvss_score,json=cvssScore,proto3,oneof" json:"cvss_score,omitempty"`
-	Limit             int32                  `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
-	Offset            int32                  `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
-	OrderBy           *OrderBy               `protobuf:"bytes,6,opt,name=order_by,json=orderBy,proto3,oneof" json:"order_by,omitempty"`
-	ExcludeNamespaces []string               `protobuf:"bytes,7,rep,name=exclude_namespaces,json=excludeNamespaces,proto3" json:"exclude_namespaces,omitempty"`
-	ExcludeClusters   []string               `protobuf:"bytes,8,rep,name=exclude_clusters,json=excludeClusters,proto3" json:"exclude_clusters,omitempty"`
-	IncludeSuppressed *bool                  `protobuf:"varint,9,opt,name=include_suppressed,json=includeSuppressed,proto3,oneof" json:"include_suppressed,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Filter    *Filter                `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
+	CveIds    []string               `protobuf:"bytes,2,rep,name=cve_ids,json=cveIds,proto3" json:"cve_ids,omitempty"`
+	CvssScore *float64               `protobuf:"fixed64,3,opt,name=cvss_score,json=cvssScore,proto3,oneof" json:"cvss_score,omitempty"`
+	Limit     int32                  `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
+	Offset    int32                  `protobuf:"varint,5,opt,name=offset,proto3" json:"offset,omitempty"`
+	OrderBy   *OrderBy               `protobuf:"bytes,6,opt,name=order_by,json=orderBy,proto3,oneof" json:"order_by,omitempty"`
+	// Deprecated: Marked as deprecated in vulnerabilities.proto.
+	ExcludeNamespaces []string `protobuf:"bytes,7,rep,name=exclude_namespaces,json=excludeNamespaces,proto3" json:"exclude_namespaces,omitempty"` // use filter.exclude_namespaces instead
+	// Deprecated: Marked as deprecated in vulnerabilities.proto.
+	ExcludeClusters   []string `protobuf:"bytes,8,rep,name=exclude_clusters,json=excludeClusters,proto3" json:"exclude_clusters,omitempty"` // use filter.exclude_clusters instead
+	IncludeSuppressed *bool    `protobuf:"varint,9,opt,name=include_suppressed,json=includeSuppressed,proto3,oneof" json:"include_suppressed,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -2501,6 +2529,7 @@ func (x *ListWorkloadsForVulnerabilityRequest) GetOrderBy() *OrderBy {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in vulnerabilities.proto.
 func (x *ListWorkloadsForVulnerabilityRequest) GetExcludeNamespaces() []string {
 	if x != nil {
 		return x.ExcludeNamespaces
@@ -2508,6 +2537,7 @@ func (x *ListWorkloadsForVulnerabilityRequest) GetExcludeNamespaces() []string {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in vulnerabilities.proto.
 func (x *ListWorkloadsForVulnerabilityRequest) GetExcludeClusters() []string {
 	if x != nil {
 		return x.ExcludeClusters
@@ -2627,14 +2657,16 @@ func (x *WorkloadForVulnerability) GetVulnerability() *Vulnerability {
 }
 
 type ListCveSummariesRequest struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Filter            *Filter                `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
-	Limit             int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
-	Offset            int32                  `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
-	OrderBy           *OrderBy               `protobuf:"bytes,4,opt,name=order_by,json=orderBy,proto3,oneof" json:"order_by,omitempty"`
-	ExcludeNamespaces []string               `protobuf:"bytes,5,rep,name=exclude_namespaces,json=excludeNamespaces,proto3" json:"exclude_namespaces,omitempty"`
-	ExcludeClusters   []string               `protobuf:"bytes,6,rep,name=exclude_clusters,json=excludeClusters,proto3" json:"exclude_clusters,omitempty"`
-	IncludeSuppressed *bool                  `protobuf:"varint,7,opt,name=include_suppressed,json=includeSuppressed,proto3,oneof" json:"include_suppressed,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Filter  *Filter                `protobuf:"bytes,1,opt,name=filter,proto3" json:"filter,omitempty"`
+	Limit   int32                  `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
+	Offset  int32                  `protobuf:"varint,3,opt,name=offset,proto3" json:"offset,omitempty"`
+	OrderBy *OrderBy               `protobuf:"bytes,4,opt,name=order_by,json=orderBy,proto3,oneof" json:"order_by,omitempty"`
+	// Deprecated: Marked as deprecated in vulnerabilities.proto.
+	ExcludeNamespaces []string `protobuf:"bytes,5,rep,name=exclude_namespaces,json=excludeNamespaces,proto3" json:"exclude_namespaces,omitempty"` // use filter.exclude_namespaces instead
+	// Deprecated: Marked as deprecated in vulnerabilities.proto.
+	ExcludeClusters   []string `protobuf:"bytes,6,rep,name=exclude_clusters,json=excludeClusters,proto3" json:"exclude_clusters,omitempty"` // use filter.exclude_clusters instead
+	IncludeSuppressed *bool    `protobuf:"varint,7,opt,name=include_suppressed,json=includeSuppressed,proto3,oneof" json:"include_suppressed,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -2697,6 +2729,7 @@ func (x *ListCveSummariesRequest) GetOrderBy() *OrderBy {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in vulnerabilities.proto.
 func (x *ListCveSummariesRequest) GetExcludeNamespaces() []string {
 	if x != nil {
 		return x.ExcludeNamespaces
@@ -2704,6 +2737,7 @@ func (x *ListCveSummariesRequest) GetExcludeNamespaces() []string {
 	return nil
 }
 
+// Deprecated: Marked as deprecated in vulnerabilities.proto.
 func (x *ListCveSummariesRequest) GetExcludeClusters() []string {
 	if x != nil {
 		return x.ExcludeClusters
@@ -4149,15 +4183,20 @@ var File_vulnerabilities_proto protoreflect.FileDescriptor
 
 const file_vulnerabilities_proto_rawDesc = "" +
 	"\n" +
-	"\x15vulnerabilities.proto\x12\x11v13s.api.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15v13s.pagination.proto\"\xb1\x02\n" +
+	"\x15vulnerabilities.proto\x12\x11v13s.api.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15v13s.pagination.proto\"\xaf\x03\n" +
 	"\x06Filter\x12\x1d\n" +
-	"\acluster\x18\x01 \x01(\tH\x00R\acluster\x88\x01\x01\x12!\n" +
-	"\tnamespace\x18\x02 \x01(\tH\x01R\tnamespace\x88\x01\x01\x12\x1f\n" +
+	"\acluster\x18\x01 \x01(\tH\x00R\acluster\x88\x01\x01\x12%\n" +
+	"\tnamespace\x18\x02 \x01(\tB\x02\x18\x01H\x01R\tnamespace\x88\x01\x01\x12\x1f\n" +
 	"\bworkload\x18\x03 \x01(\tH\x02R\bworkload\x88\x01\x01\x12(\n" +
 	"\rworkload_type\x18\x04 \x01(\tH\x03R\fworkloadType\x88\x01\x01\x12\"\n" +
 	"\n" +
 	"image_name\x18\x05 \x01(\tH\x04R\timageName\x88\x01\x01\x12 \n" +
-	"\timage_tag\x18\x06 \x01(\tH\x05R\bimageTag\x88\x01\x01B\n" +
+	"\timage_tag\x18\x06 \x01(\tH\x05R\bimageTag\x88\x01\x01\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\a \x03(\tR\n" +
+	"namespaces\x12-\n" +
+	"\x12exclude_namespaces\x18\b \x03(\tR\x11excludeNamespaces\x12)\n" +
+	"\x10exclude_clusters\x18\t \x03(\tR\x0fexcludeClustersB\n" +
 	"\n" +
 	"\b_clusterB\f\n" +
 	"\n" +
@@ -4393,7 +4432,7 @@ const file_vulnerabilities_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"z\n" +
 	")ListWorkloadsForVulnerabilityByIdResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12=\n" +
-	"\vworkloadRef\x18\x02 \x03(\v2\x1b.v13s.api.protobuf.WorkloadR\vworkloadRef\"\xc1\x03\n" +
+	"\vworkloadRef\x18\x02 \x03(\v2\x1b.v13s.api.protobuf.WorkloadR\vworkloadRef\"\xc9\x03\n" +
 	"$ListWorkloadsForVulnerabilityRequest\x121\n" +
 	"\x06filter\x18\x01 \x01(\v2\x19.v13s.api.protobuf.FilterR\x06filter\x12\x17\n" +
 	"\acve_ids\x18\x02 \x03(\tR\x06cveIds\x12\"\n" +
@@ -4401,9 +4440,9 @@ const file_vulnerabilities_proto_rawDesc = "" +
 	"cvss_score\x18\x03 \x01(\x01H\x00R\tcvssScore\x88\x01\x01\x12\x14\n" +
 	"\x05limit\x18\x04 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x05 \x01(\x05R\x06offset\x12:\n" +
-	"\border_by\x18\x06 \x01(\v2\x1a.v13s.api.protobuf.OrderByH\x01R\aorderBy\x88\x01\x01\x12-\n" +
-	"\x12exclude_namespaces\x18\a \x03(\tR\x11excludeNamespaces\x12)\n" +
-	"\x10exclude_clusters\x18\b \x03(\tR\x0fexcludeClusters\x122\n" +
+	"\border_by\x18\x06 \x01(\v2\x1a.v13s.api.protobuf.OrderByH\x01R\aorderBy\x88\x01\x01\x121\n" +
+	"\x12exclude_namespaces\x18\a \x03(\tB\x02\x18\x01R\x11excludeNamespaces\x12-\n" +
+	"\x10exclude_clusters\x18\b \x03(\tB\x02\x18\x01R\x0fexcludeClusters\x122\n" +
 	"\x12include_suppressed\x18\t \x01(\bH\x02R\x11includeSuppressed\x88\x01\x01B\r\n" +
 	"\v_cvss_scoreB\v\n" +
 	"\t_order_byB\x15\n" +
@@ -4413,14 +4452,14 @@ const file_vulnerabilities_proto_rawDesc = "" +
 	"\tpage_info\x18\x02 \x01(\v2\x1b.v13s.api.protobuf.PageInfoR\bpageInfo\"\xa2\x01\n" +
 	"\x18WorkloadForVulnerability\x12>\n" +
 	"\fworkload_ref\x18\x01 \x01(\v2\x1b.v13s.api.protobuf.WorkloadR\vworkloadRef\x12F\n" +
-	"\rvulnerability\x18\x02 \x01(\v2 .v13s.api.protobuf.VulnerabilityR\rvulnerability\"\xe8\x02\n" +
+	"\rvulnerability\x18\x02 \x01(\v2 .v13s.api.protobuf.VulnerabilityR\rvulnerability\"\xf0\x02\n" +
 	"\x17ListCveSummariesRequest\x121\n" +
 	"\x06filter\x18\x01 \x01(\v2\x19.v13s.api.protobuf.FilterR\x06filter\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\x05R\x05limit\x12\x16\n" +
 	"\x06offset\x18\x03 \x01(\x05R\x06offset\x12:\n" +
-	"\border_by\x18\x04 \x01(\v2\x1a.v13s.api.protobuf.OrderByH\x00R\aorderBy\x88\x01\x01\x12-\n" +
-	"\x12exclude_namespaces\x18\x05 \x03(\tR\x11excludeNamespaces\x12)\n" +
-	"\x10exclude_clusters\x18\x06 \x03(\tR\x0fexcludeClusters\x122\n" +
+	"\border_by\x18\x04 \x01(\v2\x1a.v13s.api.protobuf.OrderByH\x00R\aorderBy\x88\x01\x01\x121\n" +
+	"\x12exclude_namespaces\x18\x05 \x03(\tB\x02\x18\x01R\x11excludeNamespaces\x12-\n" +
+	"\x10exclude_clusters\x18\x06 \x03(\tB\x02\x18\x01R\x0fexcludeClusters\x122\n" +
 	"\x12include_suppressed\x18\a \x01(\bH\x01R\x11includeSuppressed\x88\x01\x01B\v\n" +
 	"\t_order_byB\x15\n" +
 	"\x13_include_suppressed\"\x89\x01\n" +

--- a/pkg/cli/flag/flag.go
+++ b/pkg/cli/flag/flag.go
@@ -35,6 +35,7 @@ type Options struct {
 	CvssScore         float64
 	ExcludeClusters   []string
 	ExcludeNamespaces []string
+	Namespaces        []string
 }
 
 func CommonFlags(opts *Options, excludes ...string) []cli.Flag {
@@ -132,6 +133,12 @@ func CommonFlags(opts *Options, excludes ...string) []cli.Flag {
 			Aliases:     []string{"exns"},
 			Usage:       "namespaces to exclude (can be specified multiple times)",
 			Destination: &opts.ExcludeNamespaces,
+		},
+		&cli.StringSliceFlag{
+			Name:        "namespaces",
+			Aliases:     []string{"ns"},
+			Usage:       "namespaces to include (can be specified multiple times); omit to include all",
+			Destination: &opts.Namespaces,
 		},
 	}
 	for _, f := range cFlags {
@@ -244,6 +251,10 @@ func ParseOptions(cmd *cli.Command, o *Options) []vulnerabilities.Option {
 
 	if len(o.ExcludeNamespaces) > 0 {
 		opts = append(opts, vulnerabilities.ExcludeNamespacesFilter(o.ExcludeNamespaces...))
+	}
+
+	if len(o.Namespaces) > 0 {
+		opts = append(opts, vulnerabilities.NamespacesFilter(o.Namespaces...))
 	}
 
 	if len(o.ExcludeClusters) > 0 {


### PR DESCRIPTION
## Changes

### Proto
- Deprecated `optional string namespace` on `Filter` (kept for backwards compat)
- Added `repeated string namespaces` to `Filter` — inclusion filter (replaces single-namespace pattern)
- Added `repeated string exclude_namespaces` and `repeated string exclude_clusters` to `Filter`
- Deprecated request-level `exclude_namespaces`/`exclude_clusters` on `ListWorkloadsForVulnerabilityRequest` and `ListCveSummariesRequest`

### Options (pkg/api)
- Added `NamespacesFilter(...string)` option — sets `Filter.Namespaces`
- `ExcludeNamespacesFilter`/`ExcludeClustersFilter` now populate `Filter.ExcludeNamespaces`/`Filter.ExcludeClusters`
- `Options.ExcludeNamespaces`/`Options.ExcludeClusters` kept with deprecation comment (non-breaking)
- `applyOptions` merges deprecated Options-level fields into Filter, then syncs back — both fields always populated

### SQL
- Added `namespaces` inclusion filter to `ListWorkloadsForVulnerabilities` and `ListCveSummaries`
- Pattern: `cardinality(@namespaces) = 0 OR w.namespace = ANY(@namespaces)`

### Server
- `ListWorkloadsForVulnerability`: merges `filter.GetExcludeNamespaces()` + deprecated `request.GetExcludeNamespaces()`
- `ListCveSummaries`: same merge logic
- Passes `Filter.Namespaces` to SQL params
- Added `//lint:file-ignore SA1019` on files that intentionally read deprecated proto fields for backwards compat

### Tests
- Added `TestServer_ListWorkloadsForVulnerability_NamespacesFilter` covering inclusion filter

## Backwards Compatibility
- nais/api and CLI both only use option functions — no breaking changes
- Deprecated fields remain readable and are kept in sync