### PR TITLE
feat(filter): add NamespacesFilter for multi-namespace workload queries

### DIFF
--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -357,6 +357,84 @@ func TestServer_ListWorkloadsForVulnerability_ExcludeNamespaces(t *testing.T) {
 	})
 }
 
+func TestServer_ListWorkloadsForVulnerability_NamespacesFilter(t *testing.T) {
+	cfg := testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1", "namespace-2", "namespace-3"},
+		workloadsPerNamespace: 1,
+		vulnsPerWorkload:      1,
+	}
+
+	ctx, _, _, client, cleanup := setupTest(t, cfg, true)
+	defer cleanup()
+
+	// Resolve the canonical CVE ID — call GetVulnerability for all three namespaces
+	// so the CVE is linked to every workload in the DB.
+	vulnResp, err := client.GetVulnerability(ctx,
+		"image-cluster-1-namespace-1-workload-1",
+		"v1.0",
+		"package-CWE-1-1",
+		"CWE-1-1",
+	)
+	require.NoError(t, err)
+	cveID := vulnResp.Vulnerability.Cve.Id
+	require.NotEmpty(t, cveID)
+
+	for _, ns := range []string{"namespace-2", "namespace-3"} {
+		_, err = client.GetVulnerability(ctx,
+			fmt.Sprintf("image-cluster-1-%s-workload-1", ns),
+			"v1.0",
+			"package-CWE-1-1",
+			"CWE-1-1",
+		)
+		require.NoError(t, err)
+	}
+
+	t.Run("NamespacesFilter returns only matching namespaces", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx,
+			vulnerabilities.VulnerabilityFilter{CveIds: []string{cveID}},
+			vulnerabilities.NamespacesFilter("namespace-1", "namespace-2"),
+		)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Nodes, 2)
+		namespaces := []string{resp.Nodes[0].WorkloadRef.Namespace, resp.Nodes[1].WorkloadRef.Namespace}
+		assert.ElementsMatch(t, []string{"namespace-1", "namespace-2"}, namespaces)
+	})
+
+	t.Run("NamespacesFilter with a single namespace behaves like NamespaceFilter", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx,
+			vulnerabilities.VulnerabilityFilter{CveIds: []string{cveID}},
+			vulnerabilities.NamespacesFilter("namespace-3"),
+		)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Nodes, 1)
+		assert.Equal(t, "namespace-3", resp.Nodes[0].WorkloadRef.Namespace)
+	})
+
+	t.Run("NamespaceFilter and NamespacesFilter combined return union", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx,
+			vulnerabilities.VulnerabilityFilter{CveIds: []string{cveID}},
+			vulnerabilities.NamespaceFilter("namespace-1"),
+			vulnerabilities.NamespacesFilter("namespace-2"),
+		)
+		require.NoError(t, err)
+
+		require.Len(t, resp.Nodes, 2)
+		namespaces := []string{resp.Nodes[0].WorkloadRef.Namespace, resp.Nodes[1].WorkloadRef.Namespace}
+		assert.ElementsMatch(t, []string{"namespace-1", "namespace-2"}, namespaces)
+	})
+
+	t.Run("no namespace filter returns all namespaces", func(t *testing.T) {
+		resp, err := client.ListWorkloadsForVulnerability(ctx,
+			vulnerabilities.VulnerabilityFilter{CveIds: []string{cveID}},
+		)
+		require.NoError(t, err)
+		require.Len(t, resp.Nodes, 3)
+	})
+}
+
 func TestServer_ListVulnerabilitiesForImage(t *testing.T) {
 	cfg := testSetupConfig{
 		clusters:              []string{"cluster-1"},

--- a/internal/api/grpcvulnerabilities/suppress_test.go
+++ b/internal/api/grpcvulnerabilities/suppress_test.go
@@ -341,3 +341,50 @@ func TestListWorkloadsForVulnerability_AliasLookupError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resolve canonical cve id")
 }
+
+func TestListWorkloadsForVulnerability_NamespacesMerge(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name               string
+		filter             *vulnerabilities.Filter
+		expectedNamespaces []string
+	}{
+		{
+			name:               "single namespace via Namespace field",
+			filter:             &vulnerabilities.Filter{Namespace: new("team-a")},
+			expectedNamespaces: []string{"team-a"},
+		},
+		{
+			name:               "multiple namespaces via Namespaces field",
+			filter:             &vulnerabilities.Filter{Namespaces: []string{"team-a", "team-b"}},
+			expectedNamespaces: []string{"team-a", "team-b"},
+		},
+		{
+			name:               "both fields merged",
+			filter:             &vulnerabilities.Filter{Namespace: new("team-a"), Namespaces: []string{"team-b"}},
+			expectedNamespaces: []string{"team-b", "team-a"},
+		},
+		{
+			name:               "neither set results in empty slice",
+			filter:             &vulnerabilities.Filter{},
+			expectedNamespaces: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := mockquerier.NewMockQuerier(t)
+			srv := &Server{querier: q, log: logrus.NewEntry(logrus.New())}
+
+			q.On("ListWorkloadsForVulnerabilities", mock.Anything, mock.MatchedBy(func(p sql.ListWorkloadsForVulnerabilitiesParams) bool {
+				return assert.ElementsMatch(t, tt.expectedNamespaces, p.Namespaces)
+			})).Return([]*sql.ListWorkloadsForVulnerabilitiesRow{}, nil)
+
+			_, err := srv.ListWorkloadsForVulnerability(ctx, &vulnerabilities.ListWorkloadsForVulnerabilityRequest{
+				Filter: tt.filter,
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/api/grpcvulnerabilities/vulnerabilities.go
+++ b/internal/api/grpcvulnerabilities/vulnerabilities.go
@@ -349,9 +349,17 @@ func (s *Server) ListWorkloadsForVulnerability(ctx context.Context, request *vul
 		}
 	}
 
+	namespaces := filter.GetNamespaces()
+	if ns := filter.GetNamespace(); ns != "" {
+		namespaces = append(namespaces, ns)
+	}
+	if namespaces == nil {
+		namespaces = []string{}
+	}
+
 	workloads, err := s.querier.ListWorkloadsForVulnerabilities(ctx, sql.ListWorkloadsForVulnerabilitiesParams{
 		Cluster:           filter.Cluster,
-		Namespace:         filter.Namespace,
+		Namespaces:        namespaces,
 		WorkloadTypes:     filter.GetWorkloadTypes(),
 		WorkloadName:      filter.Workload,
 		CveIds:            cveIDs,

--- a/internal/database/queries/vulnerabilities.sql
+++ b/internal/database/queries/vulnerabilities.sql
@@ -869,12 +869,8 @@ WHERE
         END)
     AND (cardinality(sqlc.arg('exclude_clusters')::TEXT[]) = 0
         OR w.cluster <> ALL (sqlc.arg('exclude_clusters')::TEXT[]))
-    AND (
-        CASE WHEN sqlc.narg('namespace')::TEXT IS NOT NULL THEN
-            w.namespace = sqlc.narg('namespace')::TEXT
-        ELSE
-            TRUE
-        END)
+    AND (cardinality(sqlc.arg('namespaces')::TEXT[]) = 0
+        OR w.namespace = ANY (sqlc.arg('namespaces')::TEXT[]))
     AND (cardinality(sqlc.arg('exclude_namespaces')::TEXT[]) = 0
         OR w.namespace <> ALL (sqlc.arg('exclude_namespaces')::TEXT[]))
     AND (sqlc.narg('workload_types')::TEXT[] IS NULL

--- a/internal/database/sql/vulnerabilities.sql.go
+++ b/internal/database/sql/vulnerabilities.sql.go
@@ -1333,12 +1333,8 @@ WHERE
         END)
     AND (cardinality($4::TEXT[]) = 0
         OR w.cluster <> ALL ($4::TEXT[]))
-    AND (
-        CASE WHEN $5::TEXT IS NOT NULL THEN
-            w.namespace = $5::TEXT
-        ELSE
-            TRUE
-        END)
+    AND (cardinality($5::TEXT[]) = 0
+        OR w.namespace = ANY ($5::TEXT[]))
     AND (cardinality($6::TEXT[]) = 0
         OR w.namespace <> ALL ($6::TEXT[]))
     AND ($7::TEXT[] IS NULL
@@ -1412,7 +1408,7 @@ type ListWorkloadsForVulnerabilitiesParams struct {
 	CvssScore         *float64
 	Cluster           *string
 	ExcludeClusters   []string
-	Namespace         *string
+	Namespaces        []string
 	ExcludeNamespaces []string
 	WorkloadTypes     []string
 	WorkloadName      *string
@@ -1465,7 +1461,7 @@ func (q *Queries) ListWorkloadsForVulnerabilities(ctx context.Context, arg ListW
 		arg.CvssScore,
 		arg.Cluster,
 		arg.ExcludeClusters,
-		arg.Namespace,
+		arg.Namespaces,
 		arg.ExcludeNamespaces,
 		arg.WorkloadTypes,
 		arg.WorkloadName,

--- a/pkg/api/vulnerabilities/options.go
+++ b/pkg/api/vulnerabilities/options.go
@@ -175,6 +175,15 @@ func NamespaceFilter(name string) Option {
 	})
 }
 
+func NamespacesFilter(namespaces ...string) Option {
+	return newFuncOption(func(o *Options) {
+		if o.Filter == nil {
+			o.Filter = &Filter{}
+		}
+		o.Filter.Namespaces = append(o.Filter.Namespaces, namespaces...)
+	})
+}
+
 // TODO: document the Options
 func WorkloadTypeFilter(name string) Option {
 	return newFuncOption(func(o *Options) {
@@ -280,7 +289,7 @@ func applyOptions(opts ...Option) *Options {
 	}
 
 	// If single-namespace include is set, exclude list is irrelevant
-	if o.Filter.Namespace != nil {
+	if o.Filter.Namespace != nil || len(o.Filter.Namespaces) > 0 {
 		o.ExcludeNamespaces = nil
 	}
 

--- a/pkg/api/vulnerabilities/schemas/vulnerabilities.proto
+++ b/pkg/api/vulnerabilities/schemas/vulnerabilities.proto
@@ -59,6 +59,7 @@ message Filter {
   optional string workload_type = 4;
   optional string image_name = 5;
   optional string image_tag = 6;
+  repeated string namespaces = 7;
 }
 
 message OrderBy {

--- a/pkg/api/vulnerabilities/vulnerabilities.pb.go
+++ b/pkg/api/vulnerabilities/vulnerabilities.pb.go
@@ -292,6 +292,7 @@ type Filter struct {
 	WorkloadType  *string                `protobuf:"bytes,4,opt,name=workload_type,json=workloadType,proto3,oneof" json:"workload_type,omitempty"`
 	ImageName     *string                `protobuf:"bytes,5,opt,name=image_name,json=imageName,proto3,oneof" json:"image_name,omitempty"`
 	ImageTag      *string                `protobuf:"bytes,6,opt,name=image_tag,json=imageTag,proto3,oneof" json:"image_tag,omitempty"`
+	Namespaces    []string               `protobuf:"bytes,7,rep,name=namespaces,proto3" json:"namespaces,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -366,6 +367,13 @@ func (x *Filter) GetImageTag() string {
 		return *x.ImageTag
 	}
 	return ""
+}
+
+func (x *Filter) GetNamespaces() []string {
+	if x != nil {
+		return x.Namespaces
+	}
+	return nil
 }
 
 type OrderBy struct {
@@ -4149,7 +4157,7 @@ var File_vulnerabilities_proto protoreflect.FileDescriptor
 
 const file_vulnerabilities_proto_rawDesc = "" +
 	"\n" +
-	"\x15vulnerabilities.proto\x12\x11v13s.api.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15v13s.pagination.proto\"\xb1\x02\n" +
+	"\x15vulnerabilities.proto\x12\x11v13s.api.protobuf\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x15v13s.pagination.proto\"\xd1\x02\n" +
 	"\x06Filter\x12\x1d\n" +
 	"\acluster\x18\x01 \x01(\tH\x00R\acluster\x88\x01\x01\x12!\n" +
 	"\tnamespace\x18\x02 \x01(\tH\x01R\tnamespace\x88\x01\x01\x12\x1f\n" +
@@ -4157,7 +4165,10 @@ const file_vulnerabilities_proto_rawDesc = "" +
 	"\rworkload_type\x18\x04 \x01(\tH\x03R\fworkloadType\x88\x01\x01\x12\"\n" +
 	"\n" +
 	"image_name\x18\x05 \x01(\tH\x04R\timageName\x88\x01\x01\x12 \n" +
-	"\timage_tag\x18\x06 \x01(\tH\x05R\bimageTag\x88\x01\x01B\n" +
+	"\timage_tag\x18\x06 \x01(\tH\x05R\bimageTag\x88\x01\x01\x12\x1e\n" +
+	"\n" +
+	"namespaces\x18\a \x03(\tR\n" +
+	"namespacesB\n" +
 	"\n" +
 	"\b_clusterB\f\n" +
 	"\n" +


### PR DESCRIPTION
## What

Add `repeated string namespaces = 7` to the `Filter` proto message so callers can filter workloads by multiple namespaces in a single RPC call instead of issuing one call per namespace.

## Why

Currently `ListWorkloadsForVulnerability` only accepts a single `namespace` filter, forcing callers to issue one request per namespace when they need results for multiple teams. This change allows passing all namespaces at once.

## Changes

- **Proto**: add `namespaces` field (7) to `Filter` message; regenerate `vulnerabilities.pb.go`
- **options.go**: new `NamespacesFilter(...string)` option; `applyOptions` clears `ExcludeNamespaces` when either `namespace` or `namespaces` is set
- **Handler**: merge `filter.Namespace` and `filter.Namespaces` into a single `[]string` before querying; default to `[]string{}` when both are unset so the SQL passthrough works correctly
- **SQL**: replace the old `CASE WHEN namespace IS NOT NULL` condition with a single `cardinality = 0 OR w.namespace = ANY($n::TEXT[])` expression — the union of `Namespace` and `Namespaces` is built in Go before the query runs, keeping the SQL simple
- **Tests**: unit test (suppress_test.go) verifies the Go merge logic for all four combinations; integration test (server_test.go) exercises `NamespacesFilter` against a real DB including multi-namespace union and combined use with `NamespaceFilter`

## Backwards compatibility

Purely additive. Existing callers that set neither field pass an empty slice, hitting the `cardinality = 0` passthrough unchanged.