### PR TITLE
feat: cleanup stale DependencyTrack source refs every 4 hours

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -24,6 +24,7 @@ const (
 	FetchVulnerabilityDataForImagesDefaultLimit        = 10
 	MarkUntrackedCronInterval                          = "*/20 * * * *" // every 20 minutes
 	MarkUnusedCronInterval                             = "*/30 * * * *" // every 30 minutes
+	CleanupStaleSourceRefsCronInterval                 = "0 */4 * * *"  // every 4 hours
 	RefreshVulnerabilitySummaryCronDailyView           = "30 4 * * *"   // every day at 6:30 AM CEST
 	RefreshWorkloadVulnerabilityLifetimesCronDailyView = "0 5 * * *"    // every day at 7:00 AM CEST (30 min later)
 	SyncKevCronInterval                                = "0 6 * * *"    // every day at 8:00 AM CEST
@@ -145,6 +146,12 @@ func (u *Updater) Run(ctx context.Context) {
 	go runScheduled(ctx, ScheduleConfig{Type: SchedulerCron, CronExpr: SyncOsvCronInterval}, "sync OSV fix versions", u.log, func() {
 		if err := u.osvFetcher.Sync(ctx); err != nil {
 			u.log.WithError(err).Error("failed to sync OSV fix versions")
+		}
+	})
+
+	go runScheduled(ctx, ScheduleConfig{Type: SchedulerCron, CronExpr: CleanupStaleSourceRefsCronInterval}, "cleanup stale source refs", u.log, func() {
+		if err := u.CleanupStaleSourceRefs(ctx); err != nil {
+			u.log.WithError(err).Error("failed to cleanup stale source refs")
 		}
 	})
 }
@@ -410,4 +417,32 @@ func sortByFields[T any](items []T, getters ...func(T) string) {
 		}
 		return false
 	})
+}
+
+func (u *Updater) CleanupStaleSourceRefs(ctx context.Context) error {
+	rows, err := u.querier.ListUnusedSourceRefs(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("listing unused source refs: %w", err)
+	}
+
+	if len(rows) == 0 {
+		u.log.Debug("no stale source refs found")
+		return nil
+	}
+
+	u.log.Infof("found %d stale source ref(s), enqueuing removal", len(rows))
+
+	for _, row := range rows {
+		if err := u.manager.AddJob(ctx, &manager.RemoveFromSourceJob{
+			ImageName: row.ImageName,
+			ImageTag:  row.ImageTag,
+		}); err != nil {
+			u.log.WithError(err).WithFields(logrus.Fields{
+				"image": row.ImageName,
+				"tag":   row.ImageTag,
+			}).Error("failed to enqueue RemoveFromSourceJob")
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Problem

The deletion pipeline in v13s is purely event-driven. When a workload is removed from a cluster, v13s relies on a Kubernetes `OnDelete` event to trigger cleanup of the corresponding DependencyTrack project. If that event is missed (informer gap, pod restart), the workload row stays in the DB, `ListWorkloadsByImage` always returns it, and `RemoveFromSourceJob` is never enqueued. The DT project lives indefinitely.

A query against production confirms **916 orphaned source refs** currently exist.

## Fix

Adds `CleanupStaleSourceRefs` — a method on `Updater` that calls `ListUnusedSourceRefs` (finds `source_refs` with no active workload row) and enqueues `RemoveFromSourceJob` for each result. This is scheduled as a cron every 4 hours.

The `RemoveFromSourceWorker` (already existing) handles the actual DT project deletion and `source_ref` cleanup.

## Changes

- `internal/updater/updater.go`: new `CleanupStaleSourceRefsCronInterval` constant and `CleanupStaleSourceRefs` method, wired into `Run()`

## Testing

All existing tests pass (`mise run generate && mise run fmt && mise run check && mise run test`).