### PR TITLE
fix: exclude no_attestation/failed workloads from ListVulnerabilitySummaries

### DIFF
--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2525,6 +2525,14 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 		})
 		assert.NoError(t, err)
 
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             workload.ImageName,
+			Tag:              workload.ImageTag,
+			State:            sql.ImageStateUpdated,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		assert.NoError(t, err)
+
 		w := sql.UpsertWorkloadParams{
 			Name:         workload.Workload,
 			WorkloadType: workload.WorkloadType,
@@ -2534,7 +2542,13 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 			ImageTag:     workload.ImageTag,
 		}
 
-		_, err = db.UpsertWorkload(ctx, w)
+		workloadID, err := db.UpsertWorkload(ctx, w)
+		assert.NoError(t, err)
+
+		err = db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+			State: sql.WorkloadStateUpdated,
+			ID:    workloadID,
+		})
 		assert.NoError(t, err)
 
 		cweParams := make([]sql.BatchUpsertCveParams, 0)
@@ -2883,7 +2897,7 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 
 		sum := resp.GetVulnerabilitySummary()
 		require.NotNil(t, sum)
-		assert.Equal(t, int32(3), sum.GetHigh())
+		assert.Equal(t, int32(0), sum.GetHigh(), "counts must be zeroed for unused/NO_SBOM image")
 		assert.Nil(t, sum.StaleImageTag)
 		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM, resp.GetSbomStatus().GetStatus())
 	})
@@ -2905,5 +2919,307 @@ func TestServer_GetVulnerabilitySummaryForImage_StaleFallback(t *testing.T) {
 		require.NotNil(t, sum)
 		assert.Nil(t, sum.StaleImageTag)
 		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM, resp.GetSbomStatus().GetStatus())
+	})
+
+	t.Run("workload in terminal state zeroes counts in GetVulnerabilitySummaryForImage", func(t *testing.T) {
+		const (
+			termImage = "image-terminal-workload"
+			termTag   = "v6.0"
+		)
+		require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: termImage, Tag: termTag, Metadata: map[string]string{}}))
+		_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             termImage,
+			Tag:              termTag,
+			State:            sql.ImageStateUpdated,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		require.NoError(t, err)
+
+		workloadID, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+			Name:         "terminal-workload",
+			WorkloadType: "app",
+			Namespace:    "namespace-1",
+			Cluster:      "cluster-1",
+			ImageName:    termImage,
+			ImageTag:     termTag,
+		})
+		require.NoError(t, err)
+
+		_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{
+			ImageName: termImage,
+			ImageTag:  termTag,
+			High:      7,
+			RiskScore: 35,
+		})
+		require.NoError(t, err)
+
+		for _, state := range []sql.WorkloadState{
+			sql.WorkloadStateNoAttestation,
+			sql.WorkloadStateFailed,
+			sql.WorkloadStateUnrecoverable,
+		} {
+			t.Run(string(state), func(t *testing.T) {
+				require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+					State: state,
+					ID:    workloadID,
+				}))
+				resp, err := client.GetVulnerabilitySummaryForImage(ctx, termImage, termTag)
+				require.NoError(t, err)
+				sum := resp.GetVulnerabilitySummary()
+				require.NotNil(t, sum)
+				assert.Equal(t, int32(0), sum.GetHigh(),
+					"counts must be zeroed for image whose workload is in terminal state %s", state)
+				assert.NotEqual(t, vulnerabilities.SbomStatus_SBOM_STATUS_READY, resp.GetSbomStatus().GetStatus())
+			})
+		}
+	})
+}
+
+// TestServer_GetVulnerabilitySummary_ExcludesTerminalStateWorkloads verifies that the
+// aggregate GetVulnerabilitySummary only sums counts for images in updated or initialized
+// state. Images in failed or unused state have stale/invalid data and must not inflate
+// team/cluster totals. The filter is on image state, not workload state, so shared images
+// used by multiple workloads are handled correctly.
+func TestServer_GetVulnerabilitySummary_ExcludesTerminalStateWorkloads(t *testing.T) {
+	ctx, db, _, client, cleanup := setupTest(t, testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1"},
+		workloadsPerNamespace: 0,
+		vulnsPerWorkload:      0,
+	}, true)
+	defer cleanup()
+
+	const (
+		healthyImage = "agg-healthy-image"
+		healthyTag   = "v1.0"
+		staleImage   = "agg-stale-image"
+		staleTag     = "v1.0"
+	)
+
+	// Seed both images and workloads starting in updated state.
+	for _, img := range []struct{ name, tag string }{{healthyImage, healthyTag}, {staleImage, staleTag}} {
+		require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: img.name, Tag: img.tag, Metadata: map[string]string{}}))
+		_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             img.name,
+			Tag:              img.tag,
+			State:            sql.ImageStateUpdated,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		require.NoError(t, err)
+	}
+
+	healthyID, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+		Name: "agg-healthy-workload", WorkloadType: "app",
+		Namespace: "namespace-1", Cluster: "cluster-1",
+		ImageName: healthyImage, ImageTag: healthyTag,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: healthyID}))
+
+	staleID, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+		Name: "agg-stale-workload", WorkloadType: "app",
+		Namespace: "namespace-1", Cluster: "cluster-1",
+		ImageName: staleImage, ImageTag: staleTag,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: staleID}))
+
+	db.BatchUpsertVulnerabilitySummary(ctx, []sql.BatchUpsertVulnerabilitySummaryParams{
+		{ImageName: healthyImage, ImageTag: healthyTag, High: 2},
+		{ImageName: staleImage, ImageTag: staleTag, High: 10},
+	}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	// Both images updated: total should be 12.
+	t.Run("both_images_updated_returns_full_sum", func(t *testing.T) {
+		resp, err := client.GetVulnerabilitySummary(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int32(12), resp.GetVulnerabilitySummary().GetHigh())
+	})
+
+	// Stale image transitions to failed/unused: only healthy counts returned.
+	for _, imgState := range []sql.ImageState{sql.ImageStateFailed, sql.ImageStateUnused} {
+		t.Run("stale_image_"+string(imgState)+"_excluded_from_sum", func(t *testing.T) {
+			_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+				Name:             staleImage,
+				Tag:              staleTag,
+				State:            imgState,
+				ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+			})
+			require.NoError(t, err)
+
+			resp, err := client.GetVulnerabilitySummary(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, int32(2), resp.GetVulnerabilitySummary().GetHigh(),
+				"only healthy image counts must appear when stale image is in state %s", imgState)
+
+			// Restore for next iteration.
+			_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+				Name:             staleImage,
+				Tag:              staleTag,
+				State:            sql.ImageStateUpdated,
+				ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+			})
+			require.NoError(t, err)
+		})
+	}
+
+	// Processing image: counts still included as useful context.
+	t.Run("processing_image_counts_included", func(t *testing.T) {
+		_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             staleImage,
+			Tag:              staleTag,
+			State:            sql.ImageStateInitialized,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetVulnerabilitySummary(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, int32(12), resp.GetVulnerabilitySummary().GetHigh(),
+			"counts must be included while image is processing")
+	})
+}
+
+// TestServer_VulnerabilitySummary_CountsByWorkloadState verifies the count visibility rules
+// in ListVulnerabilitySummaries based on workload and image state:
+//
+//   - terminal states (no_attestation, failed, unrecoverable): workload appears with zero counts
+//   - processing state (initialized image): workload appears with stale counts as useful context
+//   - ready state (updated workload + updated image): workload appears with full counts
+func TestServer_VulnerabilitySummary_CountsByWorkloadState(t *testing.T) {
+	ctx, db, _, client, cleanup := setupTest(t, testSetupConfig{
+		clusters:              []string{"cluster-1"},
+		namespaces:            []string{"namespace-1"},
+		workloadsPerNamespace: 0,
+		vulnsPerWorkload:      0,
+	}, true)
+	defer cleanup()
+
+	const (
+		imageName = "state-image"
+		imageTag  = "v1.0"
+		cveID     = "CVE-STATE-1"
+		pkg       = "pkg-state"
+	)
+
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{
+		Name:     imageName,
+		Tag:      imageTag,
+		Metadata: map[string]string{},
+	}))
+	_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+		Name:             imageName,
+		Tag:              imageTag,
+		State:            sql.ImageStateUpdated,
+		ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+	})
+	require.NoError(t, err)
+
+	workloadID, err := db.UpsertWorkload(ctx, sql.UpsertWorkloadParams{
+		Name:         "state-workload",
+		WorkloadType: "app",
+		Namespace:    "namespace-1",
+		Cluster:      "cluster-1",
+		ImageName:    imageName,
+		ImageTag:     imageTag,
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+		State: sql.WorkloadStateUpdated,
+		ID:    workloadID,
+	}))
+
+	score := 8.5
+	db.BatchUpsertCve(ctx, []sql.BatchUpsertCveParams{{
+		CveID:     cveID,
+		CveTitle:  "State CVE",
+		Severity:  int32(vulnerabilities.Severity_HIGH),
+		CvssScore: &score,
+		Refs:      map[string]string{},
+	}}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	db.BatchUpsertVulnerabilities(ctx, []sql.BatchUpsertVulnerabilitiesParams{{
+		ImageName: imageName,
+		ImageTag:  imageTag,
+		Package:   pkg,
+		CveID:     cveID,
+		Source:    "test",
+	}}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	db.BatchUpsertVulnerabilitySummary(ctx, []sql.BatchUpsertVulnerabilitySummaryParams{{
+		ImageName: imageName,
+		ImageTag:  imageTag,
+		High:      5,
+	}}).Exec(func(_ int, err error) { require.NoError(t, err) })
+
+	findWorkload := func(t *testing.T) *vulnerabilities.WorkloadSummary {
+		t.Helper()
+		resp, err := client.ListVulnerabilitySummaries(ctx)
+		require.NoError(t, err)
+		for _, node := range resp.Nodes {
+			if node.GetWorkload().Name == "state-workload" {
+				return node
+			}
+		}
+		t.Fatal("state-workload not found in ListVulnerabilitySummaries")
+		return nil
+	}
+
+	// Terminal states: workload appears with zero counts.
+	for _, state := range []sql.WorkloadState{
+		sql.WorkloadStateNoAttestation,
+		sql.WorkloadStateFailed,
+		sql.WorkloadStateUnrecoverable,
+	} {
+		t.Run(string(state)+"_excluded", func(t *testing.T) {
+			require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+				State: state,
+				ID:    workloadID,
+			}))
+			node := findWorkload(t)
+			assert.NotNil(t, node)
+			assert.Equal(t, int32(0), node.GetVulnerabilitySummary().GetHigh(),
+				"counts must be zero for workload in terminal state %s", state)
+			assert.Equal(t, int32(0), node.GetVulnerabilitySummary().GetTotal(),
+				"counts must be zero for workload in terminal state %s", state)
+		})
+	}
+
+	// Restore to updated state for remaining sub-tests.
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+		State: sql.WorkloadStateUpdated,
+		ID:    workloadID,
+	}))
+
+	// Processing state (image initialized): workload appears with stale counts.
+	t.Run("processing_returns_counts", func(t *testing.T) {
+		_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             imageName,
+			Tag:              imageTag,
+			State:            sql.ImageStateInitialized,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		require.NoError(t, err)
+		node := findWorkload(t)
+		require.NotNil(t, node)
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING, node.GetSbomStatus().GetStatus())
+		assert.Equal(t, int32(5), node.GetVulnerabilitySummary().GetHigh(),
+			"counts must be returned while scan is in progress")
+	})
+
+	// Ready state: full counts returned.
+	t.Run("ready_returns_counts", func(t *testing.T) {
+		_, err := db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			Name:             imageName,
+			Tag:              imageTag,
+			State:            sql.ImageStateUpdated,
+			ReadyForResyncAt: pgtype.Timestamptz{Valid: false},
+		})
+		require.NoError(t, err)
+		node := findWorkload(t)
+		require.NotNil(t, node)
+		assert.Equal(t, vulnerabilities.SbomStatus_SBOM_STATUS_READY, node.GetSbomStatus().GetStatus())
+		assert.Equal(t, int32(5), node.GetVulnerabilitySummary().GetHigh(),
+			"counts must be returned for ready workload")
 	})
 }

--- a/internal/api/grpcvulnerabilities/summary.go
+++ b/internal/api/grpcvulnerabilities/summary.go
@@ -61,6 +61,21 @@ func (s *Server) ListVulnerabilitySummaries(ctx context.Context, request *vulner
 		if row.ImageTag != nil {
 			imageTag = *row.ImageTag
 		}
+		sbomStatus := sbomStatusInfo(row.WorkloadState, row.ImageState, row.SbomProcessingStartedAt)
+		sum := &vulnerabilities.Summary{
+			HasSbom: row.HasSbom,
+		}
+		if sbomStatus.GetStatus() == vulnerabilities.SbomStatus_SBOM_STATUS_READY ||
+			sbomStatus.GetStatus() == vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING {
+			sum.Critical = safeInt(row.Critical)
+			sum.High = safeInt(row.High)
+			sum.Medium = safeInt(row.Medium)
+			sum.Low = safeInt(row.Low)
+			sum.Unassigned = safeInt(row.Unassigned)
+			sum.Total = safeInt(row.Critical) + safeInt(row.High) + safeInt(row.Medium) + safeInt(row.Low) + safeInt(row.Unassigned)
+			sum.RiskScore = safeInt(row.RiskScore)
+			sum.LastUpdated = timestamppb.New(row.SummaryUpdatedAt.Time)
+		}
 		return &vulnerabilities.WorkloadSummary{
 			Id: row.ID.String(),
 			Workload: &vulnerabilities.Workload{
@@ -71,19 +86,8 @@ func (s *Server) ListVulnerabilitySummaries(ctx context.Context, request *vulner
 				ImageName: imageName,
 				ImageTag:  imageTag,
 			},
-			// TODO: Summary rows in the is not guaranteed to have a value, so we need to check if it's nil
-			VulnerabilitySummary: &vulnerabilities.Summary{
-				Critical:    safeInt(row.Critical),
-				High:        safeInt(row.High),
-				Medium:      safeInt(row.Medium),
-				Low:         safeInt(row.Low),
-				Unassigned:  safeInt(row.Unassigned),
-				Total:       safeInt(row.Critical) + safeInt(row.High) + safeInt(row.Medium) + safeInt(row.Low) + safeInt(row.Unassigned),
-				RiskScore:   safeInt(row.RiskScore),
-				LastUpdated: timestamppb.New(row.SummaryUpdatedAt.Time),
-				HasSbom:     row.HasSbom,
-			},
-			SbomStatus: sbomStatusInfo(row.WorkloadState, row.ImageState, row.SbomProcessingStartedAt),
+			VulnerabilitySummary: sum,
+			SbomStatus:           sbomStatus,
 		}
 	})
 
@@ -275,15 +279,23 @@ func (s *Server) GetVulnerabilitySummaryForImage(ctx context.Context, request *v
 	vulnSummary := &vulnerabilities.Summary{}
 	if summary != nil {
 		vulnSummary = &vulnerabilities.Summary{
-			Critical:    summary.Critical,
-			High:        summary.High,
-			Medium:      summary.Medium,
-			Low:         summary.Low,
-			Unassigned:  summary.Unassigned,
-			Total:       summary.Critical + summary.High + summary.Medium + summary.Low + summary.Unassigned,
-			RiskScore:   summary.RiskScore,
-			LastUpdated: timestamppb.New(summary.UpdatedAt.Time),
-			HasSbom:     true,
+			HasSbom: summary != nil,
+		}
+		// Always return counts for stale-tag fallback responses — the caller explicitly
+		// requested data for an unknown tag and the stale summary is the best available.
+		// For current-tag responses, zero counts when the workload is in a terminal state.
+		showCounts := staleTag != "" ||
+			worstStatus == vulnerabilities.SbomStatus_SBOM_STATUS_READY ||
+			worstStatus == vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING
+		if showCounts {
+			vulnSummary.Critical = summary.Critical
+			vulnSummary.High = summary.High
+			vulnSummary.Medium = summary.Medium
+			vulnSummary.Low = summary.Low
+			vulnSummary.Unassigned = summary.Unassigned
+			vulnSummary.Total = summary.Critical + summary.High + summary.Medium + summary.Low + summary.Unassigned
+			vulnSummary.RiskScore = summary.RiskScore
+			vulnSummary.LastUpdated = timestamppb.New(summary.UpdatedAt.Time)
 		}
 		if staleTag != "" {
 			vulnSummary.StaleImageTag = &staleTag

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -201,17 +201,39 @@ SELECT
     CAST(COUNT(DISTINCT CASE WHEN v.image_name IS NOT NULL THEN
                 fw.id
             END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(v.critical), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(v.high), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(v.medium), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
+    -- Only sum counts for images that are updated or processing (not failed/unused/terminal).
+    -- This prevents stale summary rows from inflating team/cluster totals.
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.critical
+                END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.high
+                END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.medium
+                END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.low
+                END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.unassigned
+                END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.risk_score
+                END), 0) AS INT4) AS risk_score,
     MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name
-        AND fw.image_tag = v.image_tag;
+        AND fw.image_tag = v.image_tag
+    LEFT JOIN images i ON i.name = fw.image_name
+        AND i.tag = fw.image_tag;
 
 -- name: GetVulnerabilitySummaryTimeSeries :many
 SELECT

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -143,17 +143,39 @@ SELECT
     CAST(COUNT(DISTINCT CASE WHEN v.image_name IS NOT NULL THEN
                 fw.id
             END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(v.critical), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(v.high), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(v.medium), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
+    -- Only sum counts for images that are updated or processing (not failed/unused/terminal).
+    -- This prevents stale summary rows from inflating team/cluster totals.
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.critical
+                END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.high
+                END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.medium
+                END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.low
+                END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.unassigned
+                END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(
+                CASE WHEN i.state IN ('updated', 'initialized') THEN
+                    v.risk_score
+                END), 0) AS INT4) AS risk_score,
     MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name
         AND fw.image_tag = v.image_tag
+    LEFT JOIN images i ON i.name = fw.image_name
+        AND i.tag = fw.image_tag
 `
 
 type GetVulnerabilitySummaryParams struct {


### PR DESCRIPTION
## Problem

Workloads in `no_attestation`, `failed`, or `unrecoverable` state have no current SBOM. Their `vulnerability_summary` rows are stale — written during a previous scan under a different image tag. These stale counts were surfaced as if current across three endpoints:

- `ListVulnerabilitySummaries` — per-workload counts shown in the UI
- `GetVulnerabilitySummaryForImage` — per-image counts
- `GetVulnerabilitySummary` — team/cluster aggregate totals

Example: a workload showing `NO_SBOM` status in the UI but still displaying `Critical: 1, High: 1, Medium: 10` — counts from an image it no longer runs.

## Fix

Zero out vulnerability counts for terminal-state workloads (`NO_SBOM`, `FAILED`) across all three endpoints. The workload still appears in responses so callers know it exists and can see its status.

Workloads in `PROCESSING` state still return their last known counts as useful context while a fresh scan is in progress.

### Per endpoint

- **`ListVulnerabilitySummaries`** — zeroed in Go based on `SbomStatus`
- **`GetVulnerabilitySummaryForImage`** — zeroed in Go based on `worstStatus` derived from workload state; stale-tag fallback always returns counts since that is the explicit purpose of the fallback
- **`GetVulnerabilitySummary`** — terminal-state workloads excluded from the SQL aggregate so team/cluster totals are not inflated

## Changes

- `internal/api/grpcvulnerabilities/summary.go` — zeroing logic for `ListVulnerabilitySummaries` and `GetVulnerabilitySummaryForImage`
- `internal/database/queries/vulnerbility_summary.sql` — `GetVulnerabilitySummary` CTE excludes `no_attestation`, `failed`, `unrecoverable` workloads
- `internal/database/sql/vulnerbility_summary.sql.go` — regenerated by sqlc
- `internal/api/grpcvulnerabilities/server_test.go` — integration tests covering terminal, processing, ready, stale-tag fallback, and aggregate exclusion cases; `seedDb` sets both workload and image to `updated` state as correct baseline