### PR TITLE
fix(sql): gate workload_with_sbom count and vuln sums on READY state

### DIFF
--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2556,6 +2556,7 @@ func TestServer_ListWorkloadsForVulnerability_NoDuplicatesForAliasAndCanonical(t
 }
 
 func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
+	t.Helper()
 	ctx := context.Background()
 
 	for _, workload := range workloads {
@@ -2564,7 +2565,7 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 			Tag:      workload.ImageTag,
 			Metadata: map[string]string{},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		w := sql.UpsertWorkloadParams{
 			Name:         workload.Workload,
@@ -2576,22 +2577,21 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 		}
 
 		workloadID, err := db.UpsertWorkload(ctx, w)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.True(t, workloadID.Valid, "UpsertWorkload returned invalid workload ID for %q", workload.Workload)
 
-		if workloadID.Valid {
-			err = db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
-				State: sql.WorkloadStateUpdated,
-				ID:    workloadID,
-			})
-			assert.NoError(t, err)
-		}
+		err = db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+			State: sql.WorkloadStateUpdated,
+			ID:    workloadID,
+		})
+		require.NoError(t, err)
 
 		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
 			State: sql.ImageStateUpdated,
 			Name:  workload.ImageName,
 			Tag:   workload.ImageTag,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		cweParams := make([]sql.BatchUpsertCveParams, 0)
 		vulnParams := make([]sql.BatchUpsertVulnerabilitiesParams, 0)
@@ -2633,19 +2633,19 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 
 		db.BatchUpsertCve(ctx, cweParams).Exec(func(i int, err error) {
 			if err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 
 		db.BatchUpsertVulnerabilities(ctx, vulnParams).Exec(func(i int, err error) {
 			if err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 
 		db.BatchUpsertVulnerabilitySummary(ctx, sumParams).Exec(func(i int, err error) {
 			if err != nil {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/api/grpcvulnerabilities/server_test.go
+++ b/internal/api/grpcvulnerabilities/server_test.go
@@ -2575,7 +2575,22 @@ func seedDb(t *testing.T, db sql.Querier, workloads []*Workload) error {
 			ImageTag:     workload.ImageTag,
 		}
 
-		_, err = db.UpsertWorkload(ctx, w)
+		workloadID, err := db.UpsertWorkload(ctx, w)
+		assert.NoError(t, err)
+
+		if workloadID.Valid {
+			err = db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+				State: sql.WorkloadStateUpdated,
+				ID:    workloadID,
+			})
+			assert.NoError(t, err)
+		}
+
+		_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{
+			State: sql.ImageStateUpdated,
+			Name:  workload.ImageName,
+			Tag:   workload.ImageTag,
+		})
 		assert.NoError(t, err)
 
 		cweParams := make([]sql.BatchUpsertCveParams, 0)

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -185,7 +185,8 @@ WITH filtered_workloads AS (
     SELECT
         w.id,
         w.image_name,
-        w.image_tag
+        w.image_tag,
+        w.state NOT IN ('no_attestation', 'failed', 'unrecoverable') AS workload_ready
     FROM
         workloads w
     WHERE (sqlc.narg('cluster')::TEXT IS NULL
@@ -198,20 +199,59 @@ WITH filtered_workloads AS (
         OR w.name = sqlc.narg('workload_name')::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN v.image_name IS NOT NULL THEN
+    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready
+                AND i.state = 'updated' THEN
                 fw.id
             END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(v.critical), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(v.high), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(v.medium), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.critical
+                ELSE
+                    0
+                END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.high
+                ELSE
+                    0
+                END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.medium
+                ELSE
+                    0
+                END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.low
+                ELSE
+                    0
+                END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.unassigned
+                ELSE
+                    0
+                END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.risk_score
+                ELSE
+                    0
+                END), 0) AS INT4) AS risk_score,
     MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name
-        AND fw.image_tag = v.image_tag;
+        AND fw.image_tag = v.image_tag
+    LEFT JOIN images i ON i.name = fw.image_name
+        AND i.tag = fw.image_tag;
 
 -- name: GetVulnerabilitySummaryTimeSeries :many
 SELECT
@@ -281,15 +321,43 @@ WITH latest_summary_per_day AS (
         w.cluster,
         w.namespace,
         w.workload_type,
-        COALESCE(vs.critical, 0) AS critical,
-        COALESCE(vs.high, 0) AS high,
-        COALESCE(vs.medium, 0) AS medium,
-        COALESCE(vs.low, 0) AS low,
-        COALESCE(vs.unassigned, 0) AS unassigned,
-        COALESCE(vs.risk_score, 0) AS risk_score,
-(vs.id IS NOT NULL) AS has_summary
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.critical
+            END, 0) AS critical,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.high
+            END, 0) AS high,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.medium
+            END, 0) AS medium,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.low
+            END, 0) AS low,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.unassigned
+            END, 0) AS unassigned,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.risk_score
+            END, 0) AS risk_score,
+(w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+            AND img.state = 'updated'
+            AND vs.id IS NOT NULL) AS has_summary
     FROM
         workloads w
+        LEFT JOIN images img ON img.name = w.image_name
+            AND img.tag = w.image_tag
         LEFT JOIN vulnerability_summary vs ON w.image_name = vs.image_name
             AND w.image_tag = vs.image_tag
             AND vs.updated_at::DATE <= @date::DATE

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -199,53 +199,14 @@ WITH filtered_workloads AS (
         OR w.name = sqlc.narg('workload_name')::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready
-                AND i.state = 'updated' THEN
-                fw.id
-            END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.critical
-                ELSE
-                    0
-                END), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.high
-                ELSE
-                    0
-                END), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.medium
-                ELSE
-                    0
-                END), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.low
-                ELSE
-                    0
-                END), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.unassigned
-                ELSE
-                    0
-                END), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(
-                CASE WHEN fw.workload_ready
-                    AND i.state = 'updated' THEN
-                    v.risk_score
-                ELSE
-                    0
-                END), 0) AS INT4) AS risk_score,
-    MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
+    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN fw.id END) AS INT4) AS workload_with_sbom,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.critical ELSE 0 END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.high ELSE 0 END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.medium ELSE 0 END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.low ELSE 0 END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.unassigned ELSE 0 END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.risk_score ELSE 0 END), 0) AS INT4) AS risk_score,
+    MAX(CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN v.updated_at END)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -199,14 +199,59 @@ WITH filtered_workloads AS (
         OR w.name = sqlc.narg('workload_name')::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN fw.id END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.critical ELSE 0 END), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.high ELSE 0 END), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.medium ELSE 0 END), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.low ELSE 0 END), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.unassigned ELSE 0 END), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.risk_score ELSE 0 END), 0) AS INT4) AS risk_score,
-    MAX(CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN v.updated_at END)::TIMESTAMPTZ AS updated_at
+    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready
+                AND i.state = 'updated'
+                AND v.id IS NOT NULL THEN
+                fw.id
+            END) AS INT4) AS workload_with_sbom,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.critical
+                ELSE
+                    0
+                END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.high
+                ELSE
+                    0
+                END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.medium
+                ELSE
+                    0
+                END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.low
+                ELSE
+                    0
+                END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.unassigned
+                ELSE
+                    0
+                END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(
+                CASE WHEN fw.workload_ready
+                    AND i.state = 'updated' THEN
+                    v.risk_score
+                ELSE
+                    0
+                END), 0) AS INT4) AS risk_score,
+    MAX(
+        CASE WHEN fw.workload_ready
+            AND i.state = 'updated'
+            AND v.id IS NOT NULL THEN
+            v.updated_at
+        END)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -141,14 +141,14 @@ WITH filtered_workloads AS (
         OR w.name = $4::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready AND i.state = 'updated' THEN fw.id END) AS INT4) AS workload_with_sbom,
+    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN fw.id END) AS INT4) AS workload_with_sbom,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.critical ELSE 0 END), 0) AS INT4) AS critical,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.high ELSE 0 END), 0) AS INT4) AS high,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.medium ELSE 0 END), 0) AS INT4) AS medium,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.low ELSE 0 END), 0) AS INT4) AS low,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.unassigned ELSE 0 END), 0) AS INT4) AS unassigned,
     CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.risk_score ELSE 0 END), 0) AS INT4) AS risk_score,
-    MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
+    MAX(CASE WHEN fw.workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN v.updated_at END)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name
@@ -644,39 +644,39 @@ WITH latest_summary_per_day AS (
         w.cluster,
         w.namespace,
         w.workload_type,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.critical
-        END, 0) AS critical,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.high
-        END, 0) AS high,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.medium
-        END, 0) AS medium,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.low
-        END, 0) AS low,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.unassigned
-        END, 0) AS unassigned,
-        COALESCE(CASE
-            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-             AND img.state = 'updated'
-            THEN vs.risk_score
-        END, 0) AS risk_score,
-        (w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-         AND img.state = 'updated'
-         AND vs.id IS NOT NULL) AS has_summary
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.critical
+            END, 0) AS critical,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.high
+            END, 0) AS high,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.medium
+            END, 0) AS medium,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.low
+            END, 0) AS low,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.unassigned
+            END, 0) AS unassigned,
+        COALESCE(
+            CASE WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+                AND img.state = 'updated' THEN
+                vs.risk_score
+            END, 0) AS risk_score,
+(w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+            AND img.state = 'updated'
+            AND vs.id IS NOT NULL) AS has_summary
     FROM
         workloads w
         LEFT JOIN images img ON img.name = w.image_name

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -127,7 +127,8 @@ WITH filtered_workloads AS (
     SELECT
         w.id,
         w.image_name,
-        w.image_tag
+        w.image_tag,
+        w.state NOT IN ('no_attestation', 'failed', 'unrecoverable') AS workload_ready
     FROM
         workloads w
     WHERE ($1::TEXT IS NULL
@@ -140,20 +141,20 @@ WITH filtered_workloads AS (
         OR w.name = $4::TEXT))
 SELECT
     CAST(COUNT(DISTINCT fw.id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN v.image_name IS NOT NULL THEN
-                fw.id
-            END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(v.critical), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(v.high), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(v.medium), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(v.low), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(v.unassigned), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(v.risk_score), 0) AS INT4) AS risk_score,
+    CAST(COUNT(DISTINCT CASE WHEN fw.workload_ready AND i.state = 'updated' THEN fw.id END) AS INT4) AS workload_with_sbom,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.critical ELSE 0 END), 0) AS INT4) AS critical,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.high ELSE 0 END), 0) AS INT4) AS high,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.medium ELSE 0 END), 0) AS INT4) AS medium,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.low ELSE 0 END), 0) AS INT4) AS low,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.unassigned ELSE 0 END), 0) AS INT4) AS unassigned,
+    CAST(COALESCE(SUM(CASE WHEN fw.workload_ready AND i.state = 'updated' THEN v.risk_score ELSE 0 END), 0) AS INT4) AS risk_score,
     MAX(v.updated_at)::TIMESTAMPTZ AS updated_at
 FROM
     filtered_workloads fw
     LEFT JOIN vulnerability_summary v ON fw.image_name = v.image_name
         AND fw.image_tag = v.image_tag
+    LEFT JOIN images i ON i.name = fw.image_name
+        AND i.tag = fw.image_tag
 `
 
 type GetVulnerabilitySummaryParams struct {
@@ -643,15 +644,43 @@ WITH latest_summary_per_day AS (
         w.cluster,
         w.namespace,
         w.workload_type,
-        COALESCE(vs.critical, 0) AS critical,
-        COALESCE(vs.high, 0) AS high,
-        COALESCE(vs.medium, 0) AS medium,
-        COALESCE(vs.low, 0) AS low,
-        COALESCE(vs.unassigned, 0) AS unassigned,
-        COALESCE(vs.risk_score, 0) AS risk_score,
-(vs.id IS NOT NULL) AS has_summary
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.critical
+        END, 0) AS critical,
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.high
+        END, 0) AS high,
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.medium
+        END, 0) AS medium,
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.low
+        END, 0) AS low,
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.unassigned
+        END, 0) AS unassigned,
+        COALESCE(CASE
+            WHEN w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+             AND img.state = 'updated'
+            THEN vs.risk_score
+        END, 0) AS risk_score,
+        (w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
+         AND img.state = 'updated'
+         AND vs.id IS NOT NULL) AS has_summary
     FROM
         workloads w
+        LEFT JOIN images img ON img.name = w.image_name
+            AND img.tag = w.image_tag
         LEFT JOIN vulnerability_summary vs ON w.image_name = vs.image_name
             AND w.image_tag = vs.image_tag
             AND vs.updated_at::DATE <= $1::DATE

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -56,18 +56,30 @@ func TestGetVulnerabilitySummary_SbomCount(t *testing.T) {
 	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-failed", Tag: "v1"})
 	require.NoError(t, err)
 
+	// ready workload: workload_state=updated, image_state=updated, but no vulnerability_summary row yet
+	// this must NOT be counted in workload_with_sbom
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-ready-nosummary", Tag: "v1", Metadata: map[string]string{}}))
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-ready-nosummary", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-ready-nosummary", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlReadyNoSummary, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-ready-nosummary", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wlReadyNoSummary.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-ready-nosummary", Tag: "v1"})
+	require.NoError(t, err)
+
 	ns := "ns"
 	result, err := db.GetVulnerabilitySummary(ctx, sql.GetVulnerabilitySummaryParams{Namespace: &ns})
 	require.NoError(t, err)
 
-	assert.Equal(t, int32(3), result.WorkloadCount, "all 3 workloads should be counted")
-	assert.Equal(t, int32(1), result.WorkloadWithSbom, "only the ready workload should count as having sbom")
-	assert.Equal(t, int32(5), result.Critical, "counts must only include ready workloads")
+	assert.Equal(t, int32(4), result.WorkloadCount, "all 4 workloads should be counted")
+	assert.Equal(t, int32(1), result.WorkloadWithSbom, "only the ready workload with a summary row should count as having sbom")
+	assert.Equal(t, int32(5), result.Critical, "counts must only include ready workloads with a summary")
 	assert.Equal(t, int32(3), result.High)
 	assert.Equal(t, int32(2), result.Medium)
 	assert.Equal(t, int32(1), result.Low)
 	assert.Equal(t, int32(0), result.Unassigned)
 	assert.Equal(t, int32(100), result.RiskScore)
+	assert.True(t, result.UpdatedAt.Valid, "updated_at should reflect the ready summary row")
 }
 
 func TestGetVulnerabilitySummary_ImageStateFailed(t *testing.T) {

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -1,0 +1,149 @@
+//go:build integration_test
+
+package database_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/nais/v13s/internal/database/sql"
+	"github.com/nais/v13s/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetVulnerabilitySummary_SbomCount(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	// ready workload: workload_state=updated, image_state=updated, has vulnerability_summary
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-ready", Tag: "v1", Metadata: map[string]string{}}))
+	_, err := db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-ready", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-ready", ImageTag: "v1"})
+	require.NoError(t, err)
+	wl, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-ready", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wl.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-ready", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-ready", ImageTag: "v1", Critical: 5, High: 3, Medium: 2, Low: 1, Unassigned: 0, RiskScore: 100})
+	require.NoError(t, err)
+
+	// no_attestation workload: workload_state=no_attestation, image_state=updated, has stale vulnerability_summary row
+	// mirrors the aareg-behandling case — image has a summary but workload has no attestation
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-noatt", Tag: "v1", Metadata: map[string]string{}}))
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-noatt", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlNoAtt, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateNoAttestation, ID: wlNoAtt.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-noatt", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-noatt", ImageTag: "v1", Critical: 10, High: 8, Medium: 6, Low: 4, Unassigned: 2, RiskScore: 200})
+	require.NoError(t, err)
+
+	// failed workload: workload_state=failed, image_state=updated, no summary row
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-failed", Tag: "v1", Metadata: map[string]string{}}))
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-failed", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-failed", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlFailed, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-failed", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateFailed, ID: wlFailed.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-failed", Tag: "v1"})
+	require.NoError(t, err)
+
+	ns := "ns"
+	result, err := db.GetVulnerabilitySummary(ctx, sql.GetVulnerabilitySummaryParams{Namespace: &ns})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(3), result.WorkloadCount, "all 3 workloads should be counted")
+	assert.Equal(t, int32(1), result.WorkloadWithSbom, "only the ready workload should count as having sbom")
+	assert.Equal(t, int32(5), result.Critical, "counts must only include ready workloads")
+	assert.Equal(t, int32(3), result.High)
+	assert.Equal(t, int32(2), result.Medium)
+	assert.Equal(t, int32(1), result.Low)
+	assert.Equal(t, int32(0), result.Unassigned)
+	assert.Equal(t, int32(100), result.RiskScore)
+}
+
+func TestGetVulnerabilitySummary_ImageStateFailed(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	// workload_state=updated but image_state=failed — should not count as having sbom
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-imgfail", Tag: "v1", Metadata: map[string]string{}}))
+	_, err := db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-imgfail", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-imgfail", ImageTag: "v1"})
+	require.NoError(t, err)
+	wl, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-imgfail", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wl.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateFailed, Name: "img-imgfail", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-imgfail", ImageTag: "v1", Critical: 7, High: 5, Medium: 3, Low: 1, Unassigned: 0, RiskScore: 50})
+	require.NoError(t, err)
+
+	ns := "ns"
+	result, err := db.GetVulnerabilitySummary(ctx, sql.GetVulnerabilitySummaryParams{Namespace: &ns})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), result.WorkloadCount)
+	assert.Equal(t, int32(0), result.WorkloadWithSbom, "failed image state must not count as sbom ready")
+	assert.Equal(t, int32(0), result.Critical, "counts must be zero when image state is not updated")
+	assert.Equal(t, int32(0), result.RiskScore)
+}
+
+func TestRefreshVulnerabilitySummaryForDate_NoAttestationExcluded(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	// ready workload
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-snap-ready", Tag: "v1", Metadata: map[string]string{}}))
+	_, err := db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-snap-ready", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-snap-ready", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlReady, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-snap-ready", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wlReady.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-snap-ready", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-snap-ready", ImageTag: "v1", Critical: 4, High: 2, Medium: 1, Low: 0, Unassigned: 0, RiskScore: 80})
+	require.NoError(t, err)
+
+	// no_attestation workload with stale summary row on the same image
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-snap-noatt", Tag: "v1", Metadata: map[string]string{}}))
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-snap-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-snap-noatt", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlNoAtt, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-snap-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateNoAttestation, ID: wlNoAtt.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-snap-noatt", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-snap-noatt", ImageTag: "v1", Critical: 20, High: 15, Medium: 10, Low: 5, Unassigned: 1, RiskScore: 500})
+	require.NoError(t, err)
+
+	today := time.Now()
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+	require.NoError(t, db.RefreshVulnerabilitySummaryDailyView(ctx))
+
+	rows, err := db.GetVulnerabilitySummaryTimeSeries(ctx, sql.GetVulnerabilitySummaryTimeSeriesParams{
+		Since: pgtype.Timestamptz{Time: today.Add(-24 * time.Hour), Valid: true},
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	snap := rows[0]
+	assert.Equal(t, int32(4), snap.Critical, "snapshot counts must only include ready workloads")
+	assert.Equal(t, int32(2), snap.High)
+	assert.Equal(t, int32(1), snap.Medium)
+	assert.Equal(t, int32(0), snap.Low)
+	assert.Equal(t, int32(80), snap.RiskScore)
+}

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -33,18 +33,14 @@ func TestGetVulnerabilitySummary_SbomCount(t *testing.T) {
 	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-ready", ImageTag: "v1", Critical: 5, High: 3, Medium: 2, Low: 1, Unassigned: 0, RiskScore: 100})
 	require.NoError(t, err)
 
-	// no_attestation workload: workload_state=no_attestation, image_state=updated, has stale vulnerability_summary row
-	// mirrors the aareg-behandling case — image has a summary but workload has no attestation
-	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-noatt", Tag: "v1", Metadata: map[string]string{}}))
-	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-noatt", ImageTag: "v1"})
+	// no_attestation workload: shares the same image+summary as wl-ready
+	// mirrors the aareg-behandling case — multiple workloads point at one image that has a summary,
+	// but these workloads have no attestation and must not inflate the counts
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-ready", ImageTag: "v1"})
 	require.NoError(t, err)
 	wlNoAtt, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
 	require.NoError(t, err)
 	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateNoAttestation, ID: wlNoAtt.ID}))
-	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-noatt", Tag: "v1"})
-	require.NoError(t, err)
-	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-noatt", ImageTag: "v1", Critical: 10, High: 8, Medium: 6, Low: 4, Unassigned: 2, RiskScore: 200})
-	require.NoError(t, err)
 
 	// failed workload: workload_state=failed, image_state=updated, no summary row
 	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-failed", Tag: "v1", Metadata: map[string]string{}}))
@@ -130,17 +126,13 @@ func TestRefreshVulnerabilitySummaryForDate_NoAttestationExcluded(t *testing.T) 
 	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-snap-ready", ImageTag: "v1", Critical: 4, High: 2, Medium: 1, Low: 0, Unassigned: 0, RiskScore: 80})
 	require.NoError(t, err)
 
-	// no_attestation workload with stale summary row on the same image
-	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-snap-noatt", Tag: "v1", Metadata: map[string]string{}}))
-	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-snap-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-snap-noatt", ImageTag: "v1"})
+	// no_attestation workload that shares the same image+summary as wl-snap-ready
+	// without the fix, its shared summary row would have inflated the snapshot counts
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-snap-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-snap-ready", ImageTag: "v1"})
 	require.NoError(t, err)
 	wlNoAtt, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-snap-noatt", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
 	require.NoError(t, err)
 	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateNoAttestation, ID: wlNoAtt.ID}))
-	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-snap-noatt", Tag: "v1"})
-	require.NoError(t, err)
-	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-snap-noatt", ImageTag: "v1", Critical: 20, High: 15, Medium: 10, Low: 5, Unassigned: 1, RiskScore: 500})
-	require.NoError(t, err)
 
 	today := time.Now()
 	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))


### PR DESCRIPTION
## Problem

`GetVulnerabilitySummary` had three bugs:

1. **`workload_with_sbom` inflated by no_attestation workloads** — any workload whose image had a `vulnerability_summary` row was counted as having SBOM, regardless of workload or image state. In prod, 4 `aareg-behandling` workloads (`workload_state=no_attestation`) share an image that has a summary row, causing `arbeidsforhold` to show sbomCount:115 instead of 111.

2. **Aggregated vulnerability counts inflated** — `SUM(critical/high/medium/low/unassigned/risk_score)` included counts from those same stale rows.

3. **`workload_with_sbom` not gated on summary row existence** — a READY workload with no `vulnerability_summary` row yet was counted as having SBOM, inflating coverage.

4. **`updated_at` misleading** — `MAX(v.updated_at)` included rows excluded from the aggregates, so `LastUpdated` could reflect a row not in the actual result.

`RefreshVulnerabilitySummaryForDate` had the same state-blindness, baking inflated counts into daily snapshots used by the time series.

## Fix

Compute `workload_ready = w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')` in the `filtered_workloads` CTE and apply it consistently:

- `workload_with_sbom`: gated on `workload_ready AND i.state = 'updated' AND v.id IS NOT NULL`
- all `SUM` expressions: gated on `workload_ready AND i.state = 'updated'`
- `updated_at`: `MAX(CASE WHEN workload_ready AND i.state = 'updated' AND v.id IS NOT NULL THEN v.updated_at END)`

Same fix applied to `RefreshVulnerabilitySummaryForDate` so future snapshots are consistent.

## Tests

Integration tests covering the fixed cases:
- no_attestation workload sharing an image+summary with a ready workload is excluded from sbom count and sums
- failed image state excluded from sbom count and sums
- ready workload with no summary row yet does not count as having SBOM
- `updated_at` only reflects rows included in the aggregates
- `RefreshVulnerabilitySummaryForDate` snapshot excludes no_attestation workloads
- `seedDb` updated to set READY state so existing server tests reflect the new requirement

## Verification

Verified against local DB across 30 namespaces. CLI output matches direct SQL cross-checks for all counts across all tested teams.