### PR TITLE
feat(cli): add --workload-state flag to trigger sync

### DIFF
--- a/pkg/cli/commands/management.go
+++ b/pkg/cli/commands/management.go
@@ -36,6 +36,12 @@ func ManagementCommands(c vulnerabilities.Client, opts *flag.Options) []*cli.Com
 							Usage:       "filter by image state",
 							Destination: &opts.ImageState,
 						},
+						&cli.StringFlag{
+							Name:        "workload-state",
+							Aliases:     []string{"ws"},
+							Usage:       "filter by workload state (e.g. no_attestation, updated, failed)",
+							Destination: &opts.WorkloadState,
+						},
 					),
 					Action: func(ctx context.Context, cmd *cli.Command) error {
 						if err := triggerSync(ctx, opts, c); err != nil {
@@ -111,12 +117,17 @@ func triggerSync(ctx context.Context, opts *flag.Options, c vulnerabilities.Clie
 	if opts.ImageState != "" {
 		imageState = &opts.ImageState
 	}
+	var workloadState *string
+	if opts.WorkloadState != "" {
+		workloadState = &opts.WorkloadState
+	}
 	resp, err := c.Resync(ctx, &management.ResyncRequest{
-		Cluster:      cluster,
-		Namespace:    namespace,
-		Workload:     workload,
-		WorkloadType: workloadType,
-		ImageState:   imageState,
+		Cluster:       cluster,
+		Namespace:     namespace,
+		Workload:      workload,
+		WorkloadType:  workloadType,
+		ImageState:    imageState,
+		WorkloadState: workloadState,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to trigger sync: %w", err)


### PR DESCRIPTION
Adds `--workload-state` (`--ws`) flag to `trigger sync` command, allowing targeted resyncs by workload state.

Example:
```
bin/vulnz trigger sync --workload-state no_attestation
```