### PR TITLE
Fix/vuln daily workload duplicate constraint

### DIFF
--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -489,7 +489,10 @@ FROM
 
 -- name: RefreshVulnerabilitySummaryForDate :exec
 WITH latest_summary_per_day AS (
-    SELECT DISTINCT ON (w.id)
+    SELECT DISTINCT ON (w.name,
+        w.workload_type,
+        w.namespace,
+        w.cluster)
         @date::DATE AS snapshot_date,
         w.id AS workload_id,
         w.name AS workload_name,
@@ -571,8 +574,12 @@ WITH latest_summary_per_day AS (
             AND w.image_tag = vs.image_tag
             AND vs.updated_at::DATE <= @date::DATE
         ORDER BY
-            w.id,
-            vs.updated_at DESC)
+            w.name,
+            w.workload_type,
+            w.namespace,
+            w.cluster,
+            vs.updated_at DESC NULLS LAST,
+            w.id)
     INSERT INTO vuln_daily_by_workload(
         snapshot_date,
         workload_id,
@@ -619,9 +626,9 @@ WITH latest_summary_per_day AS (
         has_summary
     FROM
         latest_summary_per_day
-    ON CONFLICT (snapshot_date,
-        workload_id)
+    ON CONFLICT ON CONSTRAINT workload_type_namespace_cluster
         DO UPDATE SET
+            workload_id = EXCLUDED.workload_id,
             critical = EXCLUDED.critical,
             high = EXCLUDED.high,
             medium = EXCLUDED.medium,

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -628,7 +628,6 @@ WITH latest_summary_per_day AS (
         latest_summary_per_day
     ON CONFLICT ON CONSTRAINT workload_type_namespace_cluster
         DO UPDATE SET
-            workload_id = EXCLUDED.workload_id,
             critical = EXCLUDED.critical,
             high = EXCLUDED.high,
             medium = EXCLUDED.medium,

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -1080,7 +1080,6 @@ WITH latest_summary_per_day AS (
         latest_summary_per_day
     ON CONFLICT ON CONSTRAINT workload_type_namespace_cluster
         DO UPDATE SET
-            workload_id = EXCLUDED.workload_id,
             critical = EXCLUDED.critical,
             high = EXCLUDED.high,
             medium = EXCLUDED.medium,

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -941,7 +941,10 @@ func (q *Queries) RefreshVulnerabilitySummaryDailyView(ctx context.Context) erro
 
 const refreshVulnerabilitySummaryForDate = `-- name: RefreshVulnerabilitySummaryForDate :exec
 WITH latest_summary_per_day AS (
-    SELECT DISTINCT ON (w.id)
+    SELECT DISTINCT ON (w.name,
+        w.workload_type,
+        w.namespace,
+        w.cluster)
         $1::DATE AS snapshot_date,
         w.id AS workload_id,
         w.name AS workload_name,
@@ -1023,8 +1026,12 @@ WITH latest_summary_per_day AS (
             AND w.image_tag = vs.image_tag
             AND vs.updated_at::DATE <= $1::DATE
         ORDER BY
-            w.id,
-            vs.updated_at DESC)
+            w.name,
+            w.workload_type,
+            w.namespace,
+            w.cluster,
+            vs.updated_at DESC NULLS LAST,
+            w.id)
     INSERT INTO vuln_daily_by_workload(
         snapshot_date,
         workload_id,
@@ -1071,9 +1078,9 @@ WITH latest_summary_per_day AS (
         has_summary
     FROM
         latest_summary_per_day
-    ON CONFLICT (snapshot_date,
-        workload_id)
+    ON CONFLICT ON CONSTRAINT workload_type_namespace_cluster
         DO UPDATE SET
+            workload_id = EXCLUDED.workload_id,
             critical = EXCLUDED.critical,
             high = EXCLUDED.high,
             medium = EXCLUDED.medium,

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -187,6 +187,20 @@ func TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated(t *testing.T) {
 	// Before the fix, this second call crashed with:
 	// duplicate key value violates unique constraint "workload_type_namespace_cluster"
 	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+
+	var snapWorkloadID pgtype.UUID
+	err = pool.QueryRow(ctx, `
+		SELECT workload_id
+		FROM vuln_daily_by_workload
+		WHERE snapshot_date = $1::DATE
+			AND workload_name = $2
+			AND workload_type = $3
+			AND namespace = $4
+			AND cluster = $5
+	`, today, "wl-recreate", "app", "ns", "cl").Scan(&snapWorkloadID)
+	require.NoError(t, err)
+	assert.Equal(t, wl.ID, snapWorkloadID, "daily snapshot should keep original workload_id for the day")
+	assert.NotEqual(t, wlNew.ID, snapWorkloadID, "daily snapshot should not be rewritten to recreated workload_id")
 }
 
 func TestListVulnerabilitySummaries_WorkloadStateGating(t *testing.T) {

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -135,7 +135,8 @@ func TestRefreshVulnerabilitySummaryForDate_NoAttestationExcluded(t *testing.T) 
 	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateNoAttestation, ID: wlNoAtt.ID}))
 
 	today := time.Now()
-	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+	snapshotDate := pgtype.Date{Time: today, Valid: true}
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, snapshotDate))
 	require.NoError(t, db.RefreshVulnerabilitySummaryDailyView(ctx))
 
 	rows, err := db.GetVulnerabilitySummaryTimeSeries(ctx, sql.GetVulnerabilitySummaryTimeSeriesParams{
@@ -172,7 +173,8 @@ func TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated(t *testing.T) {
 	require.NoError(t, err)
 
 	today := time.Now()
-	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+	snapshotDate := pgtype.Date{Time: today, Valid: true}
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, snapshotDate))
 
 	// Simulate workload deletion and recreation: same logical identity, new UUID.
 	_, err = db.DeleteWorkload(ctx, sql.DeleteWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
@@ -186,7 +188,7 @@ func TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated(t *testing.T) {
 
 	// Before the fix, this second call crashed with:
 	// duplicate key value violates unique constraint "workload_type_namespace_cluster"
-	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, snapshotDate))
 
 	var snapWorkloadID pgtype.UUID
 	err = pool.QueryRow(ctx, `
@@ -197,7 +199,7 @@ func TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated(t *testing.T) {
 			AND workload_type = $3
 			AND namespace = $4
 			AND cluster = $5
-	`, today, "wl-recreate", "app", "ns", "cl").Scan(&snapWorkloadID)
+	`, snapshotDate, "wl-recreate", "app", "ns", "cl").Scan(&snapWorkloadID)
 	require.NoError(t, err)
 	assert.Equal(t, wl.ID, snapWorkloadID, "daily snapshot should keep original workload_id for the day")
 	assert.NotEqual(t, wlNew.ID, snapWorkloadID, "daily snapshot should not be rewritten to recreated workload_id")

--- a/internal/database/vulnerability_summary_test.go
+++ b/internal/database/vulnerability_summary_test.go
@@ -152,6 +152,43 @@ func TestRefreshVulnerabilitySummaryForDate_NoAttestationExcluded(t *testing.T) 
 	assert.Equal(t, int32(80), snap.RiskScore)
 }
 
+func TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	// Set up image and a ready workload with a vulnerability summary.
+	require.NoError(t, db.CreateImage(ctx, sql.CreateImageParams{Name: "img-recreate", Tag: "v1", Metadata: map[string]string{}}))
+	_, err := db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-recreate", ImageTag: "v1"})
+	require.NoError(t, err)
+	wl, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wl.ID}))
+	_, err = db.UpdateImageState(ctx, sql.UpdateImageStateParams{State: sql.ImageStateUpdated, Name: "img-recreate", Tag: "v1"})
+	require.NoError(t, err)
+	_, err = db.CreateVulnerabilitySummary(ctx, sql.CreateVulnerabilitySummaryParams{ImageName: "img-recreate", ImageTag: "v1", Critical: 3, High: 1, Medium: 0, Low: 0, Unassigned: 0, RiskScore: 35})
+	require.NoError(t, err)
+
+	today := time.Now()
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+
+	// Simulate workload deletion and recreation: same logical identity, new UUID.
+	_, err = db.DeleteWorkload(ctx, sql.DeleteWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	_, err = db.CreateWorkload(ctx, sql.CreateWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl", ImageName: "img-recreate", ImageTag: "v1"})
+	require.NoError(t, err)
+	wlNew, err := db.GetWorkload(ctx, sql.GetWorkloadParams{Name: "wl-recreate", WorkloadType: "app", Namespace: "ns", Cluster: "cl"})
+	require.NoError(t, err)
+	require.NotEqual(t, wl.ID, wlNew.ID, "recreated workload must have a new UUID")
+	require.NoError(t, db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{State: sql.WorkloadStateUpdated, ID: wlNew.ID}))
+
+	// Before the fix, this second call crashed with:
+	// duplicate key value violates unique constraint "workload_type_namespace_cluster"
+	require.NoError(t, db.RefreshVulnerabilitySummaryForDate(ctx, pgtype.Date{Time: today, Valid: true}))
+}
+
 func TestListVulnerabilitySummaries_WorkloadStateGating(t *testing.T) {
 	ctx := context.Background()
 	pool := test.GetPool(ctx, t, true)


### PR DESCRIPTION
This pull request fixes the daily vulnerability summary refresh when a workload is deleted and recreated on the same logical identity (same name/type/namespace/cluster, new UUID).

What changed
- Refresh deduplication now stays on logical workload identity instead of UUID-only selection in `RefreshVulnerabilitySummaryForDate`.
- Upsert conflict handling uses `ON CONFLICT ON CONSTRAINT workload_type_namespace_cluster` to match table uniqueness.
- On conflict, `workload_id` is now preserved (not overwritten with `EXCLUDED.workload_id`) so existing daily history rows keep their original workload UUID for that day.

Why
- Before this fix, a second refresh after workload recreation could fail with: duplicate key value violates unique constraint `workload_type_namespace_cluster`.
- The previous conflict fix variant updated `workload_id` to the recreated UUID; this update keeps crash protection while preserving historical `workload_id` stability for existing daily rows.

Tests
- Added/updated regression coverage in `TestRefreshVulnerabilitySummaryForDate_WorkloadRecreated` to assert:
  - refresh does not crash after recreate
  - daily snapshot keeps original `workload_id`
  - daily snapshot is not rewritten to recreated `workload_id`