### PR TITLE
fix: allow missing migrations to handle version gaps

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -140,7 +140,9 @@ func migrateDatabaseSchema(driver, dsn string, log logrus.FieldLogger) error {
 		log.Info("database already migrated; skipping")
 		return nil
 	}
-	return goose.Up(db, "migrations")
+	// WithAllowMissing allows goose to apply pending migrations even when there
+	// are gaps in the version history (e.g. migration 30 missing before 31).
+	return goose.Up(db, "migrations", goose.WithAllowMissing())
 }
 
 func isMigrated(db *sql.DB, migrationsDir string) (bool, error) {


### PR DESCRIPTION
## Problem

After merging migration `0032`, apps fail to start in environments where migration `0030` was never applied (DB version = 31, gap at 30):

```
found 1 missing migrations before current version 31: version 30
```

## Fix

Add `goose.WithAllowMissing()` to `goose.Up()` so it applies pending migrations even when there are gaps in the version history.

This is safe because:
- `0032` uses `ADD COLUMN IF NOT EXISTS` — idempotent
- The gap at `0030` is a known historical artifact from out-of-order merging