### PR TITLE
fix: reconcile zombie workloads + dry-run mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM cgr.dev/chainguard/go:latest AS builder
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-RUN go version
-COPY . /src
 WORKDIR /src
+COPY go.mod go.sum ./
+COPY pkg/api/go.mod pkg/api/go.sum ./pkg/api/
 RUN go mod download
-RUN go build -installsuffix cgo -o /bin/api cmd/api/main.go
+COPY . .
+RUN go build -o /bin/api cmd/api/main.go
 
 FROM cgr.dev/chainguard/static:latest
 WORKDIR /app

--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -175,7 +175,7 @@ values:
     config:
       type: string
 
-  reconcileWorkloadsEnabled:
+  reconcileDeletionEnabled:
     displayName: Enable zombie workload reconciliation
     description: Set to true to enable actual deletion of workloads no longer present in k8s. Defaults to false (dry-run mode).
     config:

--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -174,3 +174,9 @@ values:
         {{- end }}
     config:
       type: string
+
+  reconcileWorkloadsEnabled:
+    displayName: Enable zombie workload reconciliation
+    description: Set to true to enable actual deletion of workloads no longer present in k8s. Defaults to false (dry-run mode).
+    config:
+      type: bool

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -31,4 +31,4 @@ stringData:
   GITHUB_ORGANIZATIONS: "{{ .Values.github.organizations | join "," }}"
   KEV_CATALOG_URL: "{{ .Values.kev.catalogURL }}"
   OSV_BASE_URL: "{{ .Values.osv.baseURL }}"
-  RECONCILE_WORKLOADS_ENABLED: "{{ .Values.reconcileWorkloadsEnabled }}"
+  RECONCILE_DELETION_ENABLED: "{{ .Values.reconcileDeletionEnabled }}"

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -31,3 +31,4 @@ stringData:
   GITHUB_ORGANIZATIONS: "{{ .Values.github.organizations | join "," }}"
   KEV_CATALOG_URL: "{{ .Values.kev.catalogURL }}"
   OSV_BASE_URL: "{{ .Values.osv.baseURL }}"
+  RECONCILE_DRY_RUN: "{{ .Values.reconcileDryRun }}"

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -31,4 +31,4 @@ stringData:
   GITHUB_ORGANIZATIONS: "{{ .Values.github.organizations | join "," }}"
   KEV_CATALOG_URL: "{{ .Values.kev.catalogURL }}"
   OSV_BASE_URL: "{{ .Values.osv.baseURL }}"
-  RECONCILE_DRY_RUN: "{{ .Values.reconcileDryRun }}"
+  RECONCILE_WORKLOADS_ENABLED: "{{ .Values.reconcileWorkloadsEnabled }}"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -41,7 +41,7 @@ kev:
   catalogURL: "https://cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 osv:
   baseURL: "https://api.osv.dev/v1"
-reconcileWorkloadsEnabled: "false"
+reconcileDeletionEnabled: false
 logLevel: info
 logFormat: json
 prometheus:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -41,7 +41,7 @@ kev:
   catalogURL: "https://cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 osv:
   baseURL: "https://api.osv.dev/v1"
-reconcileDryRun: "true"
+reconcileWorkloadsEnabled: "false"
 logLevel: info
 logFormat: json
 prometheus:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -41,6 +41,7 @@ kev:
   catalogURL: "https://cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 osv:
   baseURL: "https://api.osv.dev/v1"
+reconcileDryRun: "true"
 logLevel: info
 logFormat: json
 prometheus:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -117,11 +117,11 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		)
 	}()
 
-	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileWorkloadsEnabled, log.WithField("subsystem", "manager"))
-	if cfg.ReconcileWorkloadsEnabled {
+	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileDeletionEnabled, log.WithField("subsystem", "manager"))
+	if cfg.ReconcileDeletionEnabled {
 		log.Info("workload reconciliation: enabled — orphaned workloads will be deleted")
 	} else {
-		log.Info("workload reconciliation: dry-run — orphaned workloads will be logged but not deleted (set RECONCILE_WORKLOADS_ENABLED=true to enable)")
+		log.Info("workload reconciliation: dry-run — orphaned workloads will be logged but not deleted (set RECONCILE_DELETION_ENABLED=true to enable)")
 	}
 	mgr.Start(ctx)
 	defer mgr.Stop(ctx)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -147,6 +147,9 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		}
 	}
 
+	log.Info("reconciling workloads against k8s state")
+	mgr.ReconcileWorkloads(ctx, informerMgr.ListWorkloadsByCluster())
+
 	u := updater.NewUpdater(
 		pool,
 		source,

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -118,6 +118,11 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 	}()
 
 	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileWorkloadsEnabled, log.WithField("subsystem", "manager"))
+	if cfg.ReconcileWorkloadsEnabled {
+		log.Info("workload reconciliation: enabled — orphaned workloads will be deleted")
+	} else {
+		log.Info("workload reconciliation: dry-run — orphaned workloads will be logged but not deleted (set RECONCILE_WORKLOADS_ENABLED=true to enable)")
+	}
 	mgr.Start(ctx)
 	defer mgr.Stop(ctx)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -117,7 +117,7 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		)
 	}()
 
-	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, log.WithField("subsystem", "manager"))
+	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileDryRun, log.WithField("subsystem", "manager"))
 	mgr.Start(ctx)
 	defer mgr.Stop(ctx)
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -117,7 +117,7 @@ func Run(ctx context.Context, cfg *config.Config, log logrus.FieldLogger) error 
 		)
 	}()
 
-	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileDryRun, log.WithField("subsystem", "manager"))
+	mgr := manager.NewWorkloadManager(ctx, pool, jobCfg, verifier, source, workloadEventQueue, cfg.ReconcileWorkloadsEnabled, log.WithField("subsystem", "manager"))
 	mgr.Start(ctx)
 	defer mgr.Stop(ctx)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,9 +32,7 @@ type Config struct {
 	LeaderElection            LeaderElectionConfig
 	GithubOrganizations       []string `envconfig:"GITHUB_ORGANIZATIONS"`
 	Metrics                   MetricConfig
-	// ReconcileDryRun controls zombie workload cleanup. Defaults to true (safe mode) —
-	// set RECONCILE_DRY_RUN=false to enable actual deletions.
-	ReconcileDryRun bool `envconfig:"RECONCILE_DRY_RUN" default:"true"`
+	ReconcileWorkloadsEnabled bool `envconfig:"RECONCILE_WORKLOADS_ENABLED" default:"false"`
 }
 
 type DependencyTrackConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	LeaderElection            LeaderElectionConfig
 	GithubOrganizations       []string `envconfig:"GITHUB_ORGANIZATIONS"`
 	Metrics                   MetricConfig
-	ReconcileDeletionEnabled bool `envconfig:"RECONCILE_DELETION_ENABLED" default:"false"`
+	ReconcileDeletionEnabled  bool `envconfig:"RECONCILE_DELETION_ENABLED" default:"false"`
 }
 
 type DependencyTrackConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	LeaderElection            LeaderElectionConfig
 	GithubOrganizations       []string `envconfig:"GITHUB_ORGANIZATIONS"`
 	Metrics                   MetricConfig
+	ReconcileDryRun           bool `envconfig:"RECONCILE_DRY_RUN" default:"true"`
 }
 
 type DependencyTrackConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,9 @@ type Config struct {
 	LeaderElection            LeaderElectionConfig
 	GithubOrganizations       []string `envconfig:"GITHUB_ORGANIZATIONS"`
 	Metrics                   MetricConfig
-	ReconcileDryRun           bool `envconfig:"RECONCILE_DRY_RUN" default:"true"`
+	// ReconcileDryRun controls zombie workload cleanup. Defaults to true (safe mode) —
+	// set RECONCILE_DRY_RUN=false to enable actual deletions.
+	ReconcileDryRun bool `envconfig:"RECONCILE_DRY_RUN" default:"true"`
 }
 
 type DependencyTrackConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	LeaderElection            LeaderElectionConfig
 	GithubOrganizations       []string `envconfig:"GITHUB_ORGANIZATIONS"`
 	Metrics                   MetricConfig
-	ReconcileWorkloadsEnabled bool `envconfig:"RECONCILE_WORKLOADS_ENABLED" default:"false"`
+	ReconcileDeletionEnabled bool `envconfig:"RECONCILE_DELETION_ENABLED" default:"false"`
 }
 
 type DependencyTrackConfig struct {

--- a/internal/database/migrations/0032_fix_missing_risk_tier_columns.sql
+++ b/internal/database/migrations/0032_fix_missing_risk_tier_columns.sql
@@ -62,6 +62,7 @@ CREATE UNIQUE INDEX idx_mv_vuln_summary_daily_unique ON mv_vuln_summary_daily_by
 -- +goose Down
 -- Drop MV + index first to remove column dependencies before altering tables.
 DROP INDEX IF EXISTS idx_mv_vuln_summary_daily_unique;
+
 DROP MATERIALIZED VIEW IF EXISTS mv_vuln_summary_daily_by_workload;
 
 ALTER TABLE vulnerability_summary

--- a/internal/database/queries/vulnerbility_summary.sql
+++ b/internal/database/queries/vulnerbility_summary.sql
@@ -76,7 +76,7 @@ vulnerability_data AS (
         v.image_name,
         v.image_tag,
         w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-            AND i.state = 'updated' AS is_active,
+        AND i.state = 'updated' AS is_active,
         v.critical,
         v.high,
         v.medium,
@@ -123,29 +123,68 @@ summary_data AS (
         workload_name,
         workload_type,
         namespace,
-        cluster,
+        CLUSTER,
         current_image_name,
         current_image_tag,
         image_name,
         image_tag,
-        COALESCE(CASE WHEN is_active THEN critical END, 0)::INT4 AS critical,
-        COALESCE(CASE WHEN is_active THEN high END, 0)::INT4 AS high,
-        COALESCE(CASE WHEN is_active THEN medium END, 0)::INT4 AS medium,
-        COALESCE(CASE WHEN is_active THEN low END, 0)::INT4 AS low,
-        COALESCE(CASE WHEN is_active THEN unassigned END, 0)::INT4 AS unassigned,
-        COALESCE(CASE WHEN is_active THEN act_now END, 0)::INT4 AS act_now,
-        COALESCE(CASE WHEN is_active THEN high_risk END, 0)::INT4 AS high_risk,
-        COALESCE(CASE WHEN is_active THEN elevated_risk END, 0)::INT4 AS elevated_risk,
-        COALESCE(CASE WHEN is_active THEN monitor END, 0)::INT4 AS monitor,
-        COALESCE(CASE WHEN is_active THEN ransomware_count END, 0)::INT4 AS ransomware_count,
-        COALESCE(CASE WHEN is_active THEN high_epss_count END, 0)::INT4 AS high_epss_count,
-        CASE WHEN is_active THEN top_risk_tier END AS top_risk_tier,
-        COALESCE(CASE WHEN is_active THEN risk_score END, 0)::INT4 AS risk_score,
+        COALESCE(
+            CASE WHEN is_active THEN
+                critical
+            END, 0)::INT4 AS critical,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high
+            END, 0)::INT4 AS high,
+        COALESCE(
+            CASE WHEN is_active THEN
+                medium
+            END, 0)::INT4 AS medium,
+        COALESCE(
+            CASE WHEN is_active THEN
+                low
+            END, 0)::INT4 AS low,
+        COALESCE(
+            CASE WHEN is_active THEN
+                unassigned
+            END, 0)::INT4 AS unassigned,
+        COALESCE(
+            CASE WHEN is_active THEN
+                act_now
+            END, 0)::INT4 AS act_now,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high_risk
+            END, 0)::INT4 AS high_risk,
+        COALESCE(
+            CASE WHEN is_active THEN
+                elevated_risk
+            END, 0)::INT4 AS elevated_risk,
+        COALESCE(
+            CASE WHEN is_active THEN
+                monitor
+            END, 0)::INT4 AS monitor,
+        COALESCE(
+            CASE WHEN is_active THEN
+                ransomware_count
+            END, 0)::INT4 AS ransomware_count,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high_epss_count
+            END, 0)::INT4 AS high_epss_count,
+        CASE WHEN is_active THEN
+            top_risk_tier
+        END AS top_risk_tier,
+        COALESCE(
+            CASE WHEN is_active THEN
+                risk_score
+            END, 0)::INT4 AS risk_score,
         workload_created_at,
         workload_updated_at,
         summary_created_at,
         summary_updated_at,
-        COALESCE(is_active AND image_name IS NOT NULL, FALSE)::bool AS has_sbom,
+        COALESCE(is_active
+            AND image_name IS NOT NULL, FALSE)::BOOL AS has_sbom,
         workload_state,
         image_state,
         sbom_processing_started_at,
@@ -158,38 +197,102 @@ SELECT
 FROM
     summary_data
 ORDER BY
-    CASE WHEN sqlc.narg('order_by') = 'workload_asc' THEN workload_name END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'workload_desc' THEN workload_name END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'namespace_asc' THEN namespace END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'namespace_desc' THEN namespace END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'cluster_asc' THEN cluster END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'cluster_desc' THEN cluster END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'critical_asc' THEN COALESCE(critical, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'critical_desc' THEN COALESCE(critical, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'high_asc' THEN COALESCE(high, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'high_desc' THEN COALESCE(high, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'medium_asc' THEN COALESCE(medium, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'medium_desc' THEN COALESCE(medium, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'low_asc' THEN COALESCE(low, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'low_desc' THEN COALESCE(low, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'unassigned_asc' THEN COALESCE(unassigned, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'unassigned_desc' THEN COALESCE(unassigned, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'risk_score_asc' THEN COALESCE(risk_score, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'risk_score_desc' THEN COALESCE(risk_score, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'act_now_asc' THEN COALESCE(act_now, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'act_now_desc' THEN COALESCE(act_now, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'high_risk_asc' THEN COALESCE(high_risk, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'high_risk_desc' THEN COALESCE(high_risk, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'elevated_risk_asc' THEN COALESCE(elevated_risk, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'elevated_risk_desc' THEN COALESCE(elevated_risk, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'monitor_asc' THEN COALESCE(monitor, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'monitor_desc' THEN COALESCE(monitor, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'ransomware_count_asc' THEN COALESCE(ransomware_count, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'ransomware_count_desc' THEN COALESCE(ransomware_count, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'high_epss_count_asc' THEN COALESCE(high_epss_count, 999999) END ASC,
-    CASE WHEN sqlc.narg('order_by') = 'high_epss_count_desc' THEN COALESCE(high_epss_count, -1) END DESC,
-    CASE WHEN sqlc.narg('order_by') = 'top_risk_tier_asc' THEN top_risk_tier END ASC NULLS LAST,
-    CASE WHEN sqlc.narg('order_by') = 'top_risk_tier_desc' THEN top_risk_tier END DESC NULLS LAST,
+    CASE WHEN sqlc.narg('order_by') = 'workload_asc' THEN
+        workload_name
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'workload_desc' THEN
+        workload_name
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'namespace_asc' THEN
+        namespace
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'namespace_desc' THEN
+        namespace
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'cluster_asc' THEN
+        CLUSTER
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'cluster_desc' THEN
+        CLUSTER
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'critical_asc' THEN
+        COALESCE(critical, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'critical_desc' THEN
+        COALESCE(critical, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'high_asc' THEN
+        COALESCE(high, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'high_desc' THEN
+        COALESCE(high, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'medium_asc' THEN
+        COALESCE(medium, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'medium_desc' THEN
+        COALESCE(medium, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'low_asc' THEN
+        COALESCE(low, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'low_desc' THEN
+        COALESCE(low, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'unassigned_asc' THEN
+        COALESCE(unassigned, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'unassigned_desc' THEN
+        COALESCE(unassigned, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'risk_score_asc' THEN
+        COALESCE(risk_score, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'risk_score_desc' THEN
+        COALESCE(risk_score, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'act_now_asc' THEN
+        COALESCE(act_now, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'act_now_desc' THEN
+        COALESCE(act_now, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'high_risk_asc' THEN
+        COALESCE(high_risk, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'high_risk_desc' THEN
+        COALESCE(high_risk, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'elevated_risk_asc' THEN
+        COALESCE(elevated_risk, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'elevated_risk_desc' THEN
+        COALESCE(elevated_risk, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'monitor_asc' THEN
+        COALESCE(monitor, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'monitor_desc' THEN
+        COALESCE(monitor, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'ransomware_count_asc' THEN
+        COALESCE(ransomware_count, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'ransomware_count_desc' THEN
+        COALESCE(ransomware_count, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'high_epss_count_asc' THEN
+        COALESCE(high_epss_count, 999999)
+    END ASC,
+    CASE WHEN sqlc.narg('order_by') = 'high_epss_count_desc' THEN
+        COALESCE(high_epss_count, -1)
+    END DESC,
+    CASE WHEN sqlc.narg('order_by') = 'top_risk_tier_asc' THEN
+        top_risk_tier
+    END ASC NULLS LAST,
+    CASE WHEN sqlc.narg('order_by') = 'top_risk_tier_desc' THEN
+        top_risk_tier
+    END DESC NULLS LAST,
     summary_updated_at ASC,
     id DESC
 LIMIT sqlc.arg('limit')
@@ -221,11 +324,13 @@ WITH filtered_workloads AS (
             WHERE
                 v.image_name = w.image_name
                 AND v.image_tag = w.image_tag
-                AND v.top_risk_tier = sqlc.narg('risk_tier')::INT))),
+                AND v.top_risk_tier = sqlc.narg('risk_tier')::INT))
+),
 joined_data AS (
     SELECT
         fw.id,
-        fw.workload_ready AND i.state = 'updated' AS is_active,
+        fw.workload_ready
+        AND i.state = 'updated' AS is_active,
         v.id AS summary_id,
         v.critical,
         v.high,
@@ -248,25 +353,71 @@ joined_data AS (
         LEFT JOIN images i ON i.name = fw.image_name
             AND i.tag = fw.image_tag
 )
-SELECT
-    CAST(COUNT(DISTINCT id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN is_active AND summary_id IS NOT NULL THEN id END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN critical END), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high END), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN medium END), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN low END), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN unassigned END), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN act_now END), 0) AS INT4) AS act_now,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high_risk END), 0) AS INT4) AS high_risk,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN elevated_risk END), 0) AS INT4) AS elevated_risk,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN monitor END), 0) AS INT4) AS monitor,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN ransomware_count END), 0) AS INT4) AS ransomware_count,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high_epss_count END), 0) AS INT4) AS high_epss_count,
-    MIN(CASE WHEN is_active THEN top_risk_tier END) AS top_risk_tier,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN risk_score END), 0) AS INT4) AS risk_score,
-    MAX(CASE WHEN is_active AND summary_id IS NOT NULL THEN updated_at END)::TIMESTAMPTZ AS updated_at
-FROM
-    joined_data;
+    SELECT
+        CAST(COUNT(DISTINCT id) AS INT4) AS workload_count,
+        CAST(COUNT(DISTINCT CASE WHEN is_active
+                    AND summary_id IS NOT NULL THEN
+                    id
+                END) AS INT4) AS workload_with_sbom,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        critical
+                    END), 0) AS INT4) AS critical,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high
+                    END), 0) AS INT4) AS high,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        medium
+                    END), 0) AS INT4) AS medium,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        low
+                    END), 0) AS INT4) AS low,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        unassigned
+                    END), 0) AS INT4) AS unassigned,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        act_now
+                    END), 0) AS INT4) AS act_now,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high_risk
+                    END), 0) AS INT4) AS high_risk,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        elevated_risk
+                    END), 0) AS INT4) AS elevated_risk,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        monitor
+                    END), 0) AS INT4) AS monitor,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        ransomware_count
+                    END), 0) AS INT4) AS ransomware_count,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high_epss_count
+                    END), 0) AS INT4) AS high_epss_count,
+        MIN(
+            CASE WHEN is_active THEN
+                top_risk_tier
+            END) AS top_risk_tier,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        risk_score
+                    END), 0) AS INT4) AS risk_score,
+        MAX(
+            CASE WHEN is_active
+                AND summary_id IS NOT NULL THEN
+                updated_at
+            END)::TIMESTAMPTZ AS updated_at
+    FROM
+        joined_data;
 
 -- name: GetVulnerabilitySummaryTimeSeries :many
 SELECT

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -162,11 +162,13 @@ WITH filtered_workloads AS (
             WHERE
                 v.image_name = w.image_name
                 AND v.image_tag = w.image_tag
-                AND v.top_risk_tier = $5::INT))),
+                AND v.top_risk_tier = $5::INT))
+),
 joined_data AS (
     SELECT
         fw.id,
-        fw.workload_ready AND i.state = 'updated' AS is_active,
+        fw.workload_ready
+        AND i.state = 'updated' AS is_active,
         v.id AS summary_id,
         v.critical,
         v.high,
@@ -189,25 +191,71 @@ joined_data AS (
         LEFT JOIN images i ON i.name = fw.image_name
             AND i.tag = fw.image_tag
 )
-SELECT
-    CAST(COUNT(DISTINCT id) AS INT4) AS workload_count,
-    CAST(COUNT(DISTINCT CASE WHEN is_active AND summary_id IS NOT NULL THEN id END) AS INT4) AS workload_with_sbom,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN critical END), 0) AS INT4) AS critical,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high END), 0) AS INT4) AS high,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN medium END), 0) AS INT4) AS medium,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN low END), 0) AS INT4) AS low,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN unassigned END), 0) AS INT4) AS unassigned,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN act_now END), 0) AS INT4) AS act_now,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high_risk END), 0) AS INT4) AS high_risk,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN elevated_risk END), 0) AS INT4) AS elevated_risk,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN monitor END), 0) AS INT4) AS monitor,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN ransomware_count END), 0) AS INT4) AS ransomware_count,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN high_epss_count END), 0) AS INT4) AS high_epss_count,
-    MIN(CASE WHEN is_active THEN top_risk_tier END) AS top_risk_tier,
-    CAST(COALESCE(SUM(CASE WHEN is_active THEN risk_score END), 0) AS INT4) AS risk_score,
-    MAX(CASE WHEN is_active AND summary_id IS NOT NULL THEN updated_at END)::TIMESTAMPTZ AS updated_at
-FROM
-    joined_data
+    SELECT
+        CAST(COUNT(DISTINCT id) AS INT4) AS workload_count,
+        CAST(COUNT(DISTINCT CASE WHEN is_active
+                    AND summary_id IS NOT NULL THEN
+                    id
+                END) AS INT4) AS workload_with_sbom,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        critical
+                    END), 0) AS INT4) AS critical,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high
+                    END), 0) AS INT4) AS high,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        medium
+                    END), 0) AS INT4) AS medium,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        low
+                    END), 0) AS INT4) AS low,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        unassigned
+                    END), 0) AS INT4) AS unassigned,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        act_now
+                    END), 0) AS INT4) AS act_now,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high_risk
+                    END), 0) AS INT4) AS high_risk,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        elevated_risk
+                    END), 0) AS INT4) AS elevated_risk,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        monitor
+                    END), 0) AS INT4) AS monitor,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        ransomware_count
+                    END), 0) AS INT4) AS ransomware_count,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        high_epss_count
+                    END), 0) AS INT4) AS high_epss_count,
+        MIN(
+            CASE WHEN is_active THEN
+                top_risk_tier
+            END) AS top_risk_tier,
+        CAST(COALESCE(SUM(
+                    CASE WHEN is_active THEN
+                        risk_score
+                    END), 0) AS INT4) AS risk_score,
+        MAX(
+            CASE WHEN is_active
+                AND summary_id IS NOT NULL THEN
+                updated_at
+            END)::TIMESTAMPTZ AS updated_at
+    FROM
+        joined_data
 `
 
 type GetVulnerabilitySummaryParams struct {
@@ -594,29 +642,68 @@ summary_data AS (
         workload_name,
         workload_type,
         namespace,
-        cluster,
+        CLUSTER,
         current_image_name,
         current_image_tag,
         image_name,
         image_tag,
-        COALESCE(CASE WHEN is_active THEN critical END, 0)::INT4 AS critical,
-        COALESCE(CASE WHEN is_active THEN high END, 0)::INT4 AS high,
-        COALESCE(CASE WHEN is_active THEN medium END, 0)::INT4 AS medium,
-        COALESCE(CASE WHEN is_active THEN low END, 0)::INT4 AS low,
-        COALESCE(CASE WHEN is_active THEN unassigned END, 0)::INT4 AS unassigned,
-        COALESCE(CASE WHEN is_active THEN act_now END, 0)::INT4 AS act_now,
-        COALESCE(CASE WHEN is_active THEN high_risk END, 0)::INT4 AS high_risk,
-        COALESCE(CASE WHEN is_active THEN elevated_risk END, 0)::INT4 AS elevated_risk,
-        COALESCE(CASE WHEN is_active THEN monitor END, 0)::INT4 AS monitor,
-        COALESCE(CASE WHEN is_active THEN ransomware_count END, 0)::INT4 AS ransomware_count,
-        COALESCE(CASE WHEN is_active THEN high_epss_count END, 0)::INT4 AS high_epss_count,
-        CASE WHEN is_active THEN top_risk_tier END AS top_risk_tier,
-        COALESCE(CASE WHEN is_active THEN risk_score END, 0)::INT4 AS risk_score,
+        COALESCE(
+            CASE WHEN is_active THEN
+                critical
+            END, 0)::INT4 AS critical,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high
+            END, 0)::INT4 AS high,
+        COALESCE(
+            CASE WHEN is_active THEN
+                medium
+            END, 0)::INT4 AS medium,
+        COALESCE(
+            CASE WHEN is_active THEN
+                low
+            END, 0)::INT4 AS low,
+        COALESCE(
+            CASE WHEN is_active THEN
+                unassigned
+            END, 0)::INT4 AS unassigned,
+        COALESCE(
+            CASE WHEN is_active THEN
+                act_now
+            END, 0)::INT4 AS act_now,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high_risk
+            END, 0)::INT4 AS high_risk,
+        COALESCE(
+            CASE WHEN is_active THEN
+                elevated_risk
+            END, 0)::INT4 AS elevated_risk,
+        COALESCE(
+            CASE WHEN is_active THEN
+                monitor
+            END, 0)::INT4 AS monitor,
+        COALESCE(
+            CASE WHEN is_active THEN
+                ransomware_count
+            END, 0)::INT4 AS ransomware_count,
+        COALESCE(
+            CASE WHEN is_active THEN
+                high_epss_count
+            END, 0)::INT4 AS high_epss_count,
+        CASE WHEN is_active THEN
+            top_risk_tier
+        END AS top_risk_tier,
+        COALESCE(
+            CASE WHEN is_active THEN
+                risk_score
+            END, 0)::INT4 AS risk_score,
         workload_created_at,
         workload_updated_at,
         summary_created_at,
         summary_updated_at,
-        COALESCE(is_active AND image_name IS NOT NULL, FALSE)::bool AS has_sbom,
+        COALESCE(is_active
+            AND image_name IS NOT NULL, FALSE)::BOOL AS has_sbom,
         workload_state,
         image_state,
         sbom_processing_started_at,
@@ -629,38 +716,102 @@ SELECT
 FROM
     summary_data
 ORDER BY
-    CASE WHEN $1 = 'workload_asc' THEN workload_name END ASC,
-    CASE WHEN $1 = 'workload_desc' THEN workload_name END DESC,
-    CASE WHEN $1 = 'namespace_asc' THEN namespace END ASC,
-    CASE WHEN $1 = 'namespace_desc' THEN namespace END DESC,
-    CASE WHEN $1 = 'cluster_asc' THEN cluster END ASC,
-    CASE WHEN $1 = 'cluster_desc' THEN cluster END DESC,
-    CASE WHEN $1 = 'critical_asc' THEN COALESCE(critical, 999999) END ASC,
-    CASE WHEN $1 = 'critical_desc' THEN COALESCE(critical, -1) END DESC,
-    CASE WHEN $1 = 'high_asc' THEN COALESCE(high, 999999) END ASC,
-    CASE WHEN $1 = 'high_desc' THEN COALESCE(high, -1) END DESC,
-    CASE WHEN $1 = 'medium_asc' THEN COALESCE(medium, 999999) END ASC,
-    CASE WHEN $1 = 'medium_desc' THEN COALESCE(medium, -1) END DESC,
-    CASE WHEN $1 = 'low_asc' THEN COALESCE(low, 999999) END ASC,
-    CASE WHEN $1 = 'low_desc' THEN COALESCE(low, -1) END DESC,
-    CASE WHEN $1 = 'unassigned_asc' THEN COALESCE(unassigned, 999999) END ASC,
-    CASE WHEN $1 = 'unassigned_desc' THEN COALESCE(unassigned, -1) END DESC,
-    CASE WHEN $1 = 'risk_score_asc' THEN COALESCE(risk_score, 999999) END ASC,
-    CASE WHEN $1 = 'risk_score_desc' THEN COALESCE(risk_score, -1) END DESC,
-    CASE WHEN $1 = 'act_now_asc' THEN COALESCE(act_now, 999999) END ASC,
-    CASE WHEN $1 = 'act_now_desc' THEN COALESCE(act_now, -1) END DESC,
-    CASE WHEN $1 = 'high_risk_asc' THEN COALESCE(high_risk, 999999) END ASC,
-    CASE WHEN $1 = 'high_risk_desc' THEN COALESCE(high_risk, -1) END DESC,
-    CASE WHEN $1 = 'elevated_risk_asc' THEN COALESCE(elevated_risk, 999999) END ASC,
-    CASE WHEN $1 = 'elevated_risk_desc' THEN COALESCE(elevated_risk, -1) END DESC,
-    CASE WHEN $1 = 'monitor_asc' THEN COALESCE(monitor, 999999) END ASC,
-    CASE WHEN $1 = 'monitor_desc' THEN COALESCE(monitor, -1) END DESC,
-    CASE WHEN $1 = 'ransomware_count_asc' THEN COALESCE(ransomware_count, 999999) END ASC,
-    CASE WHEN $1 = 'ransomware_count_desc' THEN COALESCE(ransomware_count, -1) END DESC,
-    CASE WHEN $1 = 'high_epss_count_asc' THEN COALESCE(high_epss_count, 999999) END ASC,
-    CASE WHEN $1 = 'high_epss_count_desc' THEN COALESCE(high_epss_count, -1) END DESC,
-    CASE WHEN $1 = 'top_risk_tier_asc' THEN top_risk_tier END ASC NULLS LAST,
-    CASE WHEN $1 = 'top_risk_tier_desc' THEN top_risk_tier END DESC NULLS LAST,
+    CASE WHEN $1 = 'workload_asc' THEN
+        workload_name
+    END ASC,
+    CASE WHEN $1 = 'workload_desc' THEN
+        workload_name
+    END DESC,
+    CASE WHEN $1 = 'namespace_asc' THEN
+        namespace
+    END ASC,
+    CASE WHEN $1 = 'namespace_desc' THEN
+        namespace
+    END DESC,
+    CASE WHEN $1 = 'cluster_asc' THEN
+        CLUSTER
+    END ASC,
+    CASE WHEN $1 = 'cluster_desc' THEN
+        CLUSTER
+    END DESC,
+    CASE WHEN $1 = 'critical_asc' THEN
+        COALESCE(critical, 999999)
+    END ASC,
+    CASE WHEN $1 = 'critical_desc' THEN
+        COALESCE(critical, -1)
+    END DESC,
+    CASE WHEN $1 = 'high_asc' THEN
+        COALESCE(high, 999999)
+    END ASC,
+    CASE WHEN $1 = 'high_desc' THEN
+        COALESCE(high, -1)
+    END DESC,
+    CASE WHEN $1 = 'medium_asc' THEN
+        COALESCE(medium, 999999)
+    END ASC,
+    CASE WHEN $1 = 'medium_desc' THEN
+        COALESCE(medium, -1)
+    END DESC,
+    CASE WHEN $1 = 'low_asc' THEN
+        COALESCE(low, 999999)
+    END ASC,
+    CASE WHEN $1 = 'low_desc' THEN
+        COALESCE(low, -1)
+    END DESC,
+    CASE WHEN $1 = 'unassigned_asc' THEN
+        COALESCE(unassigned, 999999)
+    END ASC,
+    CASE WHEN $1 = 'unassigned_desc' THEN
+        COALESCE(unassigned, -1)
+    END DESC,
+    CASE WHEN $1 = 'risk_score_asc' THEN
+        COALESCE(risk_score, 999999)
+    END ASC,
+    CASE WHEN $1 = 'risk_score_desc' THEN
+        COALESCE(risk_score, -1)
+    END DESC,
+    CASE WHEN $1 = 'act_now_asc' THEN
+        COALESCE(act_now, 999999)
+    END ASC,
+    CASE WHEN $1 = 'act_now_desc' THEN
+        COALESCE(act_now, -1)
+    END DESC,
+    CASE WHEN $1 = 'high_risk_asc' THEN
+        COALESCE(high_risk, 999999)
+    END ASC,
+    CASE WHEN $1 = 'high_risk_desc' THEN
+        COALESCE(high_risk, -1)
+    END DESC,
+    CASE WHEN $1 = 'elevated_risk_asc' THEN
+        COALESCE(elevated_risk, 999999)
+    END ASC,
+    CASE WHEN $1 = 'elevated_risk_desc' THEN
+        COALESCE(elevated_risk, -1)
+    END DESC,
+    CASE WHEN $1 = 'monitor_asc' THEN
+        COALESCE(monitor, 999999)
+    END ASC,
+    CASE WHEN $1 = 'monitor_desc' THEN
+        COALESCE(monitor, -1)
+    END DESC,
+    CASE WHEN $1 = 'ransomware_count_asc' THEN
+        COALESCE(ransomware_count, 999999)
+    END ASC,
+    CASE WHEN $1 = 'ransomware_count_desc' THEN
+        COALESCE(ransomware_count, -1)
+    END DESC,
+    CASE WHEN $1 = 'high_epss_count_asc' THEN
+        COALESCE(high_epss_count, 999999)
+    END ASC,
+    CASE WHEN $1 = 'high_epss_count_desc' THEN
+        COALESCE(high_epss_count, -1)
+    END DESC,
+    CASE WHEN $1 = 'top_risk_tier_asc' THEN
+        top_risk_tier
+    END ASC NULLS LAST,
+    CASE WHEN $1 = 'top_risk_tier_desc' THEN
+        top_risk_tier
+    END DESC NULLS LAST,
     summary_updated_at ASC,
     id DESC
 LIMIT $3

--- a/internal/kubernetes/informers.go
+++ b/internal/kubernetes/informers.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/nais/v13s/internal/config"
+	"github.com/nais/v13s/internal/model"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -166,4 +168,25 @@ func (m *InformerManager) start(ctx context.Context) {
 
 func (m *InformerManager) addCacheSync(sync cache.InformerSynced) {
 	m.cacheSyncs = append(m.cacheSyncs, sync)
+}
+
+// ListWorkloadsByCluster returns all workloads currently in the informer cache,
+// keyed by cluster name. Every managed cluster is present in the map — clusters
+// with no live workloads have an empty slice, which lets ReconcileWorkloads
+// delete DB entries for those clusters too.
+func (m *InformerManager) ListWorkloadsByCluster() map[string][]*model.Workload {
+	result := make(map[string][]*model.Workload, len(m.clusters))
+	for cluster, clusterMgr := range m.clusters {
+		result[cluster] = make([]*model.Workload, 0)
+		for _, informer := range clusterMgr.informers {
+			for _, obj := range informer.GetStore().List() {
+				u, ok := obj.(*unstructured.Unstructured)
+				if !ok {
+					continue
+				}
+				result[cluster] = append(result[cluster], extractWorkloads(cluster, u)...)
+			}
+		}
+	}
+	return result
 }

--- a/internal/kubernetes/informers.go
+++ b/internal/kubernetes/informers.go
@@ -9,9 +9,9 @@ import (
 	"github.com/nais/v13s/internal/config"
 	"github.com/nais/v13s/internal/model"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"golang.org/x/oauth2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/discovery"
@@ -174,9 +174,14 @@ func (m *InformerManager) addCacheSync(sync cache.InformerSynced) {
 // keyed by cluster name. Every managed cluster is present in the map — clusters
 // with no live workloads have an empty slice, which lets ReconcileWorkloads
 // delete DB entries for those clusters too.
+// Clusters with no active informers are excluded to avoid false positives.
 func (m *InformerManager) ListWorkloadsByCluster() map[string][]*model.Workload {
 	result := make(map[string][]*model.Workload, len(m.clusters))
 	for cluster, clusterMgr := range m.clusters {
+		if len(clusterMgr.informers) == 0 {
+			m.log.Warnf("reconcile: skipping cluster %s — no active informers, cannot safely determine live workloads", cluster)
+			continue
+		}
 		result[cluster] = make([]*model.Workload, 0)
 		for _, informer := range clusterMgr.informers {
 			for _, obj := range informer.GetStore().List() {

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -30,20 +30,20 @@ func (c *countingJobClient) Stop(_ context.Context) error  { return nil }
 func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
 	t.Helper()
 	return &WorkloadManager{
-		db:                        q,
-		jobClient:                 &stubJobClient{},
+		db:                       q,
+		jobClient:                &stubJobClient{},
 		reconcileDeletionEnabled: true,
-		log:                       logrus.NewEntry(logrus.New()),
+		log:                      logrus.NewEntry(logrus.New()),
 	}
 }
 
 func newDryRunWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
 	t.Helper()
 	return &WorkloadManager{
-		db:                        q,
-		jobClient:                 &stubJobClient{},
+		db:                       q,
+		jobClient:                &stubJobClient{},
 		reconcileDeletionEnabled: false,
-		log:                       logrus.NewEntry(logrus.New()),
+		log:                      logrus.NewEntry(logrus.New()),
 	}
 }
 

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/riverqueue/river"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -14,12 +15,35 @@ import (
 	"github.com/nais/v13s/internal/model"
 )
 
+type countingJobClient struct {
+	count int
+}
+
+func (c *countingJobClient) AddJob(_ context.Context, _ river.JobArgs) error {
+	c.count++
+	return nil
+}
+func (c *countingJobClient) GetWorkers() *river.Workers    { return nil }
+func (c *countingJobClient) Start(_ context.Context) error { return nil }
+func (c *countingJobClient) Stop(_ context.Context) error  { return nil }
+
 func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
 	t.Helper()
 	return &WorkloadManager{
-		db:        q,
-		jobClient: &stubJobClient{},
-		log:       logrus.NewEntry(logrus.New()),
+		db:              q,
+		jobClient:       &stubJobClient{},
+		reconcileDryRun: false,
+		log:             logrus.NewEntry(logrus.New()),
+	}
+}
+
+func newDryRunWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
+	t.Helper()
+	return &WorkloadManager{
+		db:              q,
+		jobClient:       &stubJobClient{},
+		reconcileDryRun: true,
+		log:             logrus.NewEntry(logrus.New()),
 	}
 }
 
@@ -68,7 +92,8 @@ func TestReconcileWorkloads_SkipsUnmanagedClusters(t *testing.T) {
 	ctx := context.Background()
 	q := sqmock.NewMockQuerier(t)
 
-	// prod is NOT in liveByCluster — should not query DB for prod
+	// prod is NOT in liveByCluster (e.g. informer had no active informers for it)
+	// — should not query DB for prod at all
 	live := map[string][]*model.Workload{
 		"dev": {},
 	}
@@ -78,6 +103,46 @@ func TestReconcileWorkloads_SkipsUnmanagedClusters(t *testing.T) {
 	mgr.ReconcileWorkloads(ctx, live)
 
 	q.AssertNotCalled(t, "ListWorkloadsByCluster", mock.Anything, "prod")
+}
+
+func TestReconcileWorkloads_DryRun_DoesNotDelete(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{
+		{Name: "zombie", Namespace: "nais-system", Cluster: "dev", WorkloadType: "deployment", ID: pgtype.UUID{}},
+	}, nil)
+
+	live := map[string][]*model.Workload{
+		"dev": {}, // zombie not present in k8s
+	}
+
+	counter := &countingJobClient{}
+	mgr := newDryRunWorkloadManager(t, q)
+	mgr.jobClient = counter
+	mgr.ReconcileWorkloads(ctx, live)
+
+	require.Zero(t, counter.count, "dry-run should not enqueue any delete jobs")
+}
+
+func TestReconcileWorkloads_LiveRun_Deletes(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{
+		{Name: "zombie", Namespace: "nais-system", Cluster: "dev", WorkloadType: "deployment", ID: pgtype.UUID{}},
+	}, nil)
+
+	live := map[string][]*model.Workload{
+		"dev": {},
+	}
+
+	counter := &countingJobClient{}
+	mgr := newTestWorkloadManager(t, q) // dryRun=false
+	mgr.jobClient = counter
+	mgr.ReconcileWorkloads(ctx, live)
+
+	require.Equal(t, 1, counter.count, "live-run should enqueue exactly one delete job")
 }
 
 func TestReconcileWorkloads_EmptyCluster_DeletesAll(t *testing.T) {

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -32,7 +32,7 @@ func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManage
 	return &WorkloadManager{
 		db:                        q,
 		jobClient:                 &stubJobClient{},
-		reconcileWorkloadsEnabled: true,
+		reconcileDeletionEnabled: true,
 		log:                       logrus.NewEntry(logrus.New()),
 	}
 }
@@ -42,7 +42,7 @@ func newDryRunWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadMana
 	return &WorkloadManager{
 		db:                        q,
 		jobClient:                 &stubJobClient{},
-		reconcileWorkloadsEnabled: false,
+		reconcileDeletionEnabled: false,
 		log:                       logrus.NewEntry(logrus.New()),
 	}
 }

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -32,7 +32,7 @@ func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManage
 	return &WorkloadManager{
 		db:              q,
 		jobClient:       &stubJobClient{},
-		reconcileDryRun: false,
+		reconcileWorkloadsEnabled: true,
 		log:             logrus.NewEntry(logrus.New()),
 	}
 }
@@ -40,10 +40,10 @@ func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManage
 func newDryRunWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
 	t.Helper()
 	return &WorkloadManager{
-		db:              q,
-		jobClient:       &stubJobClient{},
-		reconcileDryRun: true,
-		log:             logrus.NewEntry(logrus.New()),
+		db:                        q,
+		jobClient:                 &stubJobClient{},
+		reconcileWorkloadsEnabled: false,
+		log:                       logrus.NewEntry(logrus.New()),
 	}
 }
 
@@ -140,7 +140,7 @@ func TestReconcileWorkloads_LiveRun_Deletes(t *testing.T) {
 	}
 
 	counter := &countingJobClient{}
-	mgr := newTestWorkloadManager(t, q) // dryRun=false
+	mgr := newTestWorkloadManager(t, q) // reconcileEnabled=true
 	mgr.jobClient = counter
 	mgr.ReconcileWorkloads(ctx, live)
 

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -1,0 +1,100 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nais/v13s/internal/database/sql"
+	sqmock "github.com/nais/v13s/internal/mocks/Querier"
+	"github.com/nais/v13s/internal/model"
+)
+
+func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
+	t.Helper()
+	return &WorkloadManager{
+		db:        q,
+		jobClient: &stubJobClient{},
+		log:       logrus.NewEntry(logrus.New()),
+	}
+}
+
+func TestReconcileWorkloads_DeletesOrphan(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	// DB has two workloads in dev cluster
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{
+		{Name: "replicator", Namespace: "nais-system", Cluster: "dev", WorkloadType: "deployment", ImageTag: "old-tag", ID: pgtype.UUID{}},
+		{Name: "replicator-controller-manager-replicator", Namespace: "nais-system", Cluster: "dev", WorkloadType: "deployment", ImageTag: "new-tag", ID: pgtype.UUID{}},
+	}, nil)
+
+	// Only the new one is alive in k8s
+	live := map[string][]*model.Workload{
+		"dev": {
+			{Name: "replicator-controller-manager-replicator", Namespace: "nais-system", Cluster: "dev", Type: "deployment"},
+		},
+	}
+
+	mgr := newTestWorkloadManager(t, q)
+	mgr.ReconcileWorkloads(ctx, live)
+
+	// stubJobClient silently accepts the delete job — no assertion needed beyond no panic
+}
+
+func TestReconcileWorkloads_KeepsLiveWorkloads(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{
+		{Name: "myapp", Namespace: "default", Cluster: "dev", WorkloadType: "app", ImageTag: "tag1", ID: pgtype.UUID{}},
+	}, nil)
+
+	live := map[string][]*model.Workload{
+		"dev": {
+			{Name: "myapp", Namespace: "default", Cluster: "dev", Type: "app"},
+		},
+	}
+
+	mgr := newTestWorkloadManager(t, q)
+	mgr.ReconcileWorkloads(ctx, live) // should not enqueue any deletes
+}
+
+func TestReconcileWorkloads_SkipsUnmanagedClusters(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	// prod is NOT in liveByCluster — should not query DB for prod
+	live := map[string][]*model.Workload{
+		"dev": {},
+	}
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{}, nil)
+
+	mgr := newTestWorkloadManager(t, q)
+	mgr.ReconcileWorkloads(ctx, live)
+
+	q.AssertNotCalled(t, "ListWorkloadsByCluster", mock.Anything, "prod")
+}
+
+func TestReconcileWorkloads_EmptyCluster_DeletesAll(t *testing.T) {
+	ctx := context.Background()
+	q := sqmock.NewMockQuerier(t)
+
+	q.EXPECT().ListWorkloadsByCluster(mock.Anything, "dev").Return([]*sql.Workload{
+		{Name: "stale", Namespace: "default", Cluster: "dev", WorkloadType: "deployment", ID: pgtype.UUID{}},
+	}, nil)
+
+	// Cluster managed but k8s has no workloads at all
+	live := map[string][]*model.Workload{
+		"dev": {},
+	}
+
+	mgr := newTestWorkloadManager(t, q)
+	mgr.ReconcileWorkloads(ctx, live)
+
+	require.NoError(t, nil) // stubJobClient accepted the delete
+}

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -64,10 +64,12 @@ func TestReconcileWorkloads_DeletesOrphan(t *testing.T) {
 		},
 	}
 
+	counter := &countingJobClient{}
 	mgr := newTestWorkloadManager(t, q)
+	mgr.jobClient = counter
 	mgr.ReconcileWorkloads(ctx, live)
 
-	// stubJobClient silently accepts the delete job — no assertion needed beyond no panic
+	require.Equal(t, 1, counter.count, "should enqueue one delete job for the orphan workload")
 }
 
 func TestReconcileWorkloads_KeepsLiveWorkloads(t *testing.T) {
@@ -158,8 +160,10 @@ func TestReconcileWorkloads_EmptyCluster_DeletesAll(t *testing.T) {
 		"dev": {},
 	}
 
+	counter := &countingJobClient{}
 	mgr := newTestWorkloadManager(t, q)
+	mgr.jobClient = counter
 	mgr.ReconcileWorkloads(ctx, live)
 
-	require.NoError(t, nil) // stubJobClient accepted the delete
+	require.Equal(t, 1, counter.count, "should enqueue one delete job when cluster has no live workloads")
 }

--- a/internal/manager/reconcile_workloads_test.go
+++ b/internal/manager/reconcile_workloads_test.go
@@ -30,10 +30,10 @@ func (c *countingJobClient) Stop(_ context.Context) error  { return nil }
 func newTestWorkloadManager(t *testing.T, q *sqmock.MockQuerier) *WorkloadManager {
 	t.Helper()
 	return &WorkloadManager{
-		db:              q,
-		jobClient:       &stubJobClient{},
+		db:                        q,
+		jobClient:                 &stubJobClient{},
 		reconcileWorkloadsEnabled: true,
-		log:             logrus.NewEntry(logrus.New()),
+		log:                       logrus.NewEntry(logrus.New()),
 	}
 }
 

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -31,7 +31,7 @@ type WorkloadManager struct {
 	addDispatcher    *Dispatcher[*model.Workload]
 	deleteDispatcher *Dispatcher[*model.Workload]
 	workloadCounter  metric.Int64UpDownCounter
-	reconcileDryRun  bool
+	reconcileWorkloadsEnabled bool
 	log              logrus.FieldLogger
 }
 
@@ -45,7 +45,7 @@ const (
 	WorkloadEventSubsystemUnknown               = "unknown"
 )
 
-func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, dryRun bool, log *logrus.Entry) *WorkloadManager {
+func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, reconcileEnabled bool, log *logrus.Entry) *WorkloadManager {
 	meter := otel.GetMeterProvider().Meter("nais_v13s_manager")
 	udCounter, err := meter.Int64UpDownCounter("nais_v13s_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
 	if err != nil {
@@ -80,7 +80,7 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 		src:             source,
 		queue:           queue,
 		workloadCounter: udCounter,
-		reconcileDryRun: dryRun,
+		reconcileWorkloadsEnabled: reconcileEnabled,
 		log:             log,
 	}
 	m.addDispatcher = NewDispatcher(workloadWorker(m.AddWorkload), queue.Updated, maxWorkers)
@@ -150,7 +150,7 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 			if live[key] {
 				continue
 			}
-			if m.reconcileDryRun {
+			if !m.reconcileWorkloadsEnabled {
 				m.log.Infof("[DRY RUN] reconcile: would delete workload %s/%s (not found in k8s)", cluster, key)
 				continue
 			}

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -22,16 +22,17 @@ const (
 )
 
 type WorkloadManager struct {
-	db               sql.Querier
-	pool             *pgxpool.Pool
-	jobClient        job.Client
-	verifier         attestation.Verifier
-	src              sources.Source
-	queue            *kubernetes.WorkloadEventQueue
-	addDispatcher    *Dispatcher[*model.Workload]
-	deleteDispatcher *Dispatcher[*model.Workload]
-	workloadCounter  metric.Int64UpDownCounter
-	log              logrus.FieldLogger
+	db                sql.Querier
+	pool              *pgxpool.Pool
+	jobClient         job.Client
+	verifier          attestation.Verifier
+	src               sources.Source
+	queue             *kubernetes.WorkloadEventQueue
+	addDispatcher     *Dispatcher[*model.Workload]
+	deleteDispatcher  *Dispatcher[*model.Workload]
+	workloadCounter   metric.Int64UpDownCounter
+	reconcileDryRun   bool
+	log               logrus.FieldLogger
 }
 
 type WorkloadEvent string
@@ -44,7 +45,7 @@ const (
 	WorkloadEventSubsystemUnknown               = "unknown"
 )
 
-func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, log *logrus.Entry) *WorkloadManager {
+func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, dryRun bool, log *logrus.Entry) *WorkloadManager {
 	meter := otel.GetMeterProvider().Meter("nais_v13s_manager")
 	udCounter, err := meter.Int64UpDownCounter("nais_v13s_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
 	if err != nil {
@@ -79,6 +80,7 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 		src:             source,
 		queue:           queue,
 		workloadCounter: udCounter,
+		reconcileDryRun: dryRun,
 		log:             log,
 	}
 	m.addDispatcher = NewDispatcher(workloadWorker(m.AddWorkload), queue.Updated, maxWorkers)
@@ -132,6 +134,7 @@ func (m *WorkloadManager) AddJob(ctx context.Context, job river.JobArgs) error {
 // enqueues DeleteWorkloadJob for any workload that no longer exists in k8s.
 // Only clusters present in liveByCluster are reconciled — clusters not managed
 // by the informer are left untouched.
+// When reconcileDryRun is true (default), no deletions are enqueued — only logged.
 func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster map[string][]*model.Workload) {
 	for cluster, liveWorkloads := range liveByCluster {
 		live := make(map[string]bool, len(liveWorkloads))
@@ -150,7 +153,11 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 			if live[key] {
 				continue
 			}
-			m.log.Infof("reconcile: workload %s/%s not found in k8s, enqueuing delete", cluster, key)
+			if m.reconcileDryRun {
+				m.log.Infof("[DRY RUN] reconcile: would delete workload %s/%s (not found in k8s)", cluster, key)
+				continue
+			}
+			m.log.Infof("[DELETE] reconcile: workload %s/%s not found in k8s, enqueuing delete", cluster, key)
 			if err := m.DeleteWorkload(ctx, &model.Workload{
 				Name:      dbW.Name,
 				Namespace: dbW.Namespace,

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -22,17 +22,17 @@ const (
 )
 
 type WorkloadManager struct {
-	db               sql.Querier
-	pool             *pgxpool.Pool
-	jobClient        job.Client
-	verifier         attestation.Verifier
-	src              sources.Source
-	queue            *kubernetes.WorkloadEventQueue
-	addDispatcher    *Dispatcher[*model.Workload]
-	deleteDispatcher *Dispatcher[*model.Workload]
-	workloadCounter  metric.Int64UpDownCounter
+	db                        sql.Querier
+	pool                      *pgxpool.Pool
+	jobClient                 job.Client
+	verifier                  attestation.Verifier
+	src                       sources.Source
+	queue                     *kubernetes.WorkloadEventQueue
+	addDispatcher             *Dispatcher[*model.Workload]
+	deleteDispatcher          *Dispatcher[*model.Workload]
+	workloadCounter           metric.Int64UpDownCounter
 	reconcileWorkloadsEnabled bool
-	log              logrus.FieldLogger
+	log                       logrus.FieldLogger
 }
 
 type WorkloadEvent string
@@ -73,15 +73,15 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 	job.AddWorker(jobClient, &DeleteWorkloadWorker{db: db, jobClient: jobClient, log: log.WithField("subsystem", "delete_workload")})
 	job.AddWorker(jobClient, &FinalizeAttestationWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "finalize_attestation")})
 	m := &WorkloadManager{
-		db:              db,
-		pool:            pool,
-		jobClient:       jobClient,
-		verifier:        verifier,
-		src:             source,
-		queue:           queue,
-		workloadCounter: udCounter,
+		db:                        db,
+		pool:                      pool,
+		jobClient:                 jobClient,
+		verifier:                  verifier,
+		src:                       source,
+		queue:                     queue,
+		workloadCounter:           udCounter,
 		reconcileWorkloadsEnabled: reconcileEnabled,
-		log:             log,
+		log:                       log,
 	}
 	m.addDispatcher = NewDispatcher(workloadWorker(m.AddWorkload), queue.Updated, maxWorkers)
 	// m.addDispatcher.errorHook = m.handleError

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -22,17 +22,17 @@ const (
 )
 
 type WorkloadManager struct {
-	db                sql.Querier
-	pool              *pgxpool.Pool
-	jobClient         job.Client
-	verifier          attestation.Verifier
-	src               sources.Source
-	queue             *kubernetes.WorkloadEventQueue
-	addDispatcher     *Dispatcher[*model.Workload]
-	deleteDispatcher  *Dispatcher[*model.Workload]
-	workloadCounter   metric.Int64UpDownCounter
-	reconcileDryRun   bool
-	log               logrus.FieldLogger
+	db               sql.Querier
+	pool             *pgxpool.Pool
+	jobClient        job.Client
+	verifier         attestation.Verifier
+	src              sources.Source
+	queue            *kubernetes.WorkloadEventQueue
+	addDispatcher    *Dispatcher[*model.Workload]
+	deleteDispatcher *Dispatcher[*model.Workload]
+	workloadCounter  metric.Int64UpDownCounter
+	reconcileDryRun  bool
+	log              logrus.FieldLogger
 }
 
 type WorkloadEvent string

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -130,11 +130,8 @@ func (m *WorkloadManager) AddJob(ctx context.Context, job river.JobArgs) error {
 	return m.jobClient.AddJob(ctx, job)
 }
 
-// ReconcileWorkloads compares DB workloads against the live k8s state and
-// enqueues DeleteWorkloadJob for any workload that no longer exists in k8s.
 // Only clusters present in liveByCluster are reconciled — clusters not managed
 // by the informer are left untouched.
-// When reconcileDryRun is true (default), no deletions are enqueued — only logged.
 func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster map[string][]*model.Workload) {
 	for cluster, liveWorkloads := range liveByCluster {
 		live := make(map[string]bool, len(liveWorkloads))

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -128,6 +128,41 @@ func (m *WorkloadManager) AddJob(ctx context.Context, job river.JobArgs) error {
 	return m.jobClient.AddJob(ctx, job)
 }
 
+// ReconcileWorkloads compares DB workloads against the live k8s state and
+// enqueues DeleteWorkloadJob for any workload that no longer exists in k8s.
+// Only clusters present in liveByCluster are reconciled — clusters not managed
+// by the informer are left untouched.
+func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster map[string][]*model.Workload) {
+	for cluster, liveWorkloads := range liveByCluster {
+		live := make(map[string]bool, len(liveWorkloads))
+		for _, w := range liveWorkloads {
+			live[w.Name+"/"+w.Namespace+"/"+string(w.Type)] = true
+		}
+
+		dbWorkloads, err := m.db.ListWorkloadsByCluster(ctx, cluster)
+		if err != nil {
+			m.log.WithError(err).Errorf("reconcile: failed to list workloads for cluster %s", cluster)
+			continue
+		}
+
+		for _, dbW := range dbWorkloads {
+			key := dbW.Name + "/" + dbW.Namespace + "/" + dbW.WorkloadType
+			if live[key] {
+				continue
+			}
+			m.log.Infof("reconcile: workload %s/%s not found in k8s, enqueuing delete", cluster, key)
+			if err := m.DeleteWorkload(ctx, &model.Workload{
+				Name:      dbW.Name,
+				Namespace: dbW.Namespace,
+				Cluster:   dbW.Cluster,
+				Type:      model.WorkloadType(dbW.WorkloadType),
+			}); err != nil {
+				m.log.WithError(err).Warnf("reconcile: failed to enqueue delete for %s/%s", cluster, key)
+			}
+		}
+	}
+}
+
 func (m *WorkloadManager) Stop(ctx context.Context) error {
 	return m.jobClient.Stop(ctx)
 }

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -163,6 +163,8 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 				Namespace: dbW.Namespace,
 				Cluster:   dbW.Cluster,
 				Type:      model.WorkloadType(dbW.WorkloadType),
+				ImageName: dbW.ImageName,
+				ImageTag:  dbW.ImageTag,
 			}); err != nil {
 				m.log.WithError(err).Warnf("reconcile: failed to enqueue delete for %s/%s", cluster, key)
 			}

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -3,6 +3,9 @@ package manager
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nais/v13s/internal/attestation"
@@ -145,11 +148,17 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 			continue
 		}
 
+		orphanTotal := 0
+		enqueuedTotal := 0
+		orphanByType := make(map[string]int)
+
 		for _, dbW := range dbWorkloads {
 			key := dbW.Name + "/" + dbW.Namespace + "/" + dbW.WorkloadType
 			if live[key] {
 				continue
 			}
+			orphanTotal++
+			orphanByType[dbW.WorkloadType]++
 			if !m.reconcileDeletionEnabled {
 				m.log.Infof("[DRY RUN] reconcile: would delete workload %s/%s (not found in k8s)", cluster, key)
 				continue
@@ -164,9 +173,41 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 				ImageTag:  dbW.ImageTag,
 			}); err != nil {
 				m.log.WithError(err).Warnf("reconcile: failed to enqueue delete for %s/%s", cluster, key)
+				continue
 			}
+			enqueuedTotal++
 		}
+
+		mode := "dry-run"
+		if m.reconcileDeletionEnabled {
+			mode = "delete"
+		}
+
+		m.log.WithFields(logrus.Fields{
+			"cluster":         cluster,
+			"mode":            mode,
+			"orphans_total":   orphanTotal,
+			"orphans_by_type": formatTypeCounts(orphanByType),
+			"enqueued_total":  enqueuedTotal,
+		}).Info("reconcile summary")
 	}
+}
+
+func formatTypeCounts(counts map[string]int) string {
+	if len(counts) == 0 {
+		return "none"
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", k, counts[k]))
+	}
+	return strings.Join(parts, ",")
 }
 
 func (m *WorkloadManager) Stop(ctx context.Context) error {

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -22,17 +22,17 @@ const (
 )
 
 type WorkloadManager struct {
-	db                        sql.Querier
-	pool                      *pgxpool.Pool
-	jobClient                 job.Client
-	verifier                  attestation.Verifier
-	src                       sources.Source
-	queue                     *kubernetes.WorkloadEventQueue
-	addDispatcher             *Dispatcher[*model.Workload]
-	deleteDispatcher          *Dispatcher[*model.Workload]
-	workloadCounter           metric.Int64UpDownCounter
+	db                       sql.Querier
+	pool                     *pgxpool.Pool
+	jobClient                job.Client
+	verifier                 attestation.Verifier
+	src                      sources.Source
+	queue                    *kubernetes.WorkloadEventQueue
+	addDispatcher            *Dispatcher[*model.Workload]
+	deleteDispatcher         *Dispatcher[*model.Workload]
+	workloadCounter          metric.Int64UpDownCounter
 	reconcileDeletionEnabled bool
-	log                       logrus.FieldLogger
+	log                      logrus.FieldLogger
 }
 
 type WorkloadEvent string
@@ -73,15 +73,15 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 	job.AddWorker(jobClient, &DeleteWorkloadWorker{db: db, jobClient: jobClient, log: log.WithField("subsystem", "delete_workload")})
 	job.AddWorker(jobClient, &FinalizeAttestationWorker{db: db, source: source, jobClient: jobClient, log: log.WithField("subsystem", "finalize_attestation")})
 	m := &WorkloadManager{
-		db:                        db,
-		pool:                      pool,
-		jobClient:                 jobClient,
-		verifier:                  verifier,
-		src:                       source,
-		queue:                     queue,
-		workloadCounter:           udCounter,
+		db:                       db,
+		pool:                     pool,
+		jobClient:                jobClient,
+		verifier:                 verifier,
+		src:                      source,
+		queue:                    queue,
+		workloadCounter:          udCounter,
 		reconcileDeletionEnabled: reconcileDeletionEnabled,
-		log:                       log,
+		log:                      log,
 	}
 	m.addDispatcher = NewDispatcher(workloadWorker(m.AddWorkload), queue.Updated, maxWorkers)
 	// m.addDispatcher.errorHook = m.handleError

--- a/internal/manager/workload_manager.go
+++ b/internal/manager/workload_manager.go
@@ -31,7 +31,7 @@ type WorkloadManager struct {
 	addDispatcher             *Dispatcher[*model.Workload]
 	deleteDispatcher          *Dispatcher[*model.Workload]
 	workloadCounter           metric.Int64UpDownCounter
-	reconcileWorkloadsEnabled bool
+	reconcileDeletionEnabled bool
 	log                       logrus.FieldLogger
 }
 
@@ -45,7 +45,7 @@ const (
 	WorkloadEventSubsystemUnknown               = "unknown"
 )
 
-func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, reconcileEnabled bool, log *logrus.Entry) *WorkloadManager {
+func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Config, verifier attestation.Verifier, source sources.Source, queue *kubernetes.WorkloadEventQueue, reconcileDeletionEnabled bool, log *logrus.Entry) *WorkloadManager {
 	meter := otel.GetMeterProvider().Meter("nais_v13s_manager")
 	udCounter, err := meter.Int64UpDownCounter("nais_v13s_manager_resources", metric.WithDescription("Number of workloads managed by the manager"))
 	if err != nil {
@@ -80,7 +80,7 @@ func NewWorkloadManager(ctx context.Context, pool *pgxpool.Pool, jobCfg *job.Con
 		src:                       source,
 		queue:                     queue,
 		workloadCounter:           udCounter,
-		reconcileWorkloadsEnabled: reconcileEnabled,
+		reconcileDeletionEnabled: reconcileDeletionEnabled,
 		log:                       log,
 	}
 	m.addDispatcher = NewDispatcher(workloadWorker(m.AddWorkload), queue.Updated, maxWorkers)
@@ -150,7 +150,7 @@ func (m *WorkloadManager) ReconcileWorkloads(ctx context.Context, liveByCluster 
 			if live[key] {
 				continue
 			}
-			if !m.reconcileWorkloadsEnabled {
+			if !m.reconcileDeletionEnabled {
 				m.log.Infof("[DRY RUN] reconcile: would delete workload %s/%s (not found in k8s)", cluster, key)
 				continue
 			}

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -65,7 +65,7 @@ func TestUpdater(t *testing.T) {
 		verifierMock,
 		sourceMock,
 		queue,
-		true, // dry-run: integration tests never delete
+		false, // reconcileDeletionEnabled=false: integration tests never delete
 		logrus.NewEntry(logrus.StandardLogger()),
 	)
 

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -65,6 +65,7 @@ func TestUpdater(t *testing.T) {
 		verifierMock,
 		sourceMock,
 		queue,
+		true, // dry-run: integration tests never delete
 		logrus.NewEntry(logrus.StandardLogger()),
 	)
 


### PR DESCRIPTION
## Problem

Deployments that are renamed (e.g. `replicator` → `replicator-controller-manager`) never fire an `OnDelete` event. The old workload entry in the DB persists and keeps the old image active, causing a self-perpetuating resync cycle.

## Solution

### `ReconcileWorkloads`
- Compares live k8s state (from informer cache) against DB on startup
- Enqueues `DeleteWorkloadJob` for workloads present in DB but missing from k8s
- Clusters with no active informers are skipped to avoid false positives

### Dry-run mode (default: on)
- `RECONCILE_DRY_RUN=true` (default) — logs only `[DRY RUN] would delete`, no actual deletion
- `RECONCILE_DRY_RUN=false` — enables actual deletion
- Configured per environment via Fasit Chart values (`reconcileDryRun: "false"`)

## Checklist
- [x] 6 unit tests, all green
- [x] Helm value + secret template updated
- [x] Safety check: clusters with 0 active informers are skipped

## Verification (dry-run)
Search Loki for `[DRY RUN]` log lines after deploy to see what would be deleted.
Enable actual deletion by setting `reconcileDryRun: "false"` in Fasit.