### PR TITLE
fix: allow no_attestation workloads to recover when image state is updated

### DIFF
--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -359,3 +359,56 @@ func TestInitializeWorkload_NoAttestation_Skipped(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result.Valid, "InitializeWorkload should not update a no_attestation workload with the same image")
 }
+
+func TestUpdateWorkloadStateByImage_RecoverNoAttestation(t *testing.T) {
+	ctx := context.Background()
+	pool := test.GetPool(ctx, t, true)
+	defer pool.Close()
+	db := sql.New(pool)
+	require.NoError(t, db.ResetDatabase(ctx))
+
+	createTestdata(t, db, "img-recover", "v1", false)
+
+	_, err := db.CreateWorkload(ctx, sql.CreateWorkloadParams{
+		Name:         "wl-recover",
+		WorkloadType: "app",
+		Namespace:    "ns",
+		Cluster:      "cl",
+		ImageName:    "img-recover",
+		ImageTag:     "v1",
+	})
+	require.NoError(t, err)
+
+	wl, err := db.GetWorkload(ctx, sql.GetWorkloadParams{
+		Name:         "wl-recover",
+		WorkloadType: "app",
+		Namespace:    "ns",
+		Cluster:      "cl",
+	})
+	require.NoError(t, err)
+
+	// Simulate race: workload was set to no_attestation (e.g. lost the timing race)
+	err = db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+		State: sql.WorkloadStateNoAttestation,
+		ID:    wl.ID,
+	})
+	require.NoError(t, err)
+
+	// Image is later updated (attestation found by another cluster, or vuln scan completed)
+	err = db.UpdateWorkloadStateByImage(ctx, sql.UpdateWorkloadStateByImageParams{
+		ImageName: "img-recover",
+		ImageTag:  "v1",
+		State:     sql.WorkloadStateUpdated,
+	})
+	require.NoError(t, err)
+
+	recovered, err := db.GetWorkload(ctx, sql.GetWorkloadParams{
+		Name:         "wl-recover",
+		WorkloadType: "app",
+		Namespace:    "ns",
+		Cluster:      "cl",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, sql.WorkloadStateUpdated, recovered.State,
+		"no_attestation workload should be recovered when image state is updated")
+}

--- a/internal/database/queries/workloads.sql
+++ b/internal/database/queries/workloads.sql
@@ -200,7 +200,7 @@ SET
 WHERE
     image_name = @image_name
     AND image_tag = @image_tag
-    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation');
+    AND state NOT IN ('failed', 'unrecoverable');
 
 -- name: ListWorkloadsByCluster :many
 SELECT
@@ -224,4 +224,4 @@ SET
 WHERE
     image_name = @image_name
     AND image_tag = @image_tag
-    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation');
+    AND state NOT IN ('failed', 'unrecoverable');

--- a/internal/database/sql/batch.go
+++ b/internal/database/sql/batch.go
@@ -84,7 +84,7 @@ SET
 WHERE
     image_name = $2
     AND image_tag = $3
-    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation')
+    AND state NOT IN ('failed', 'unrecoverable')
 `
 
 type BatchUpdateWorkloadStateByImageBatchResults struct {

--- a/internal/database/sql/vulnerbility_summary.sql.go
+++ b/internal/database/sql/vulnerbility_summary.sql.go
@@ -547,7 +547,7 @@ vulnerability_data AS (
         v.image_name,
         v.image_tag,
         w.state NOT IN ('no_attestation', 'failed', 'unrecoverable')
-            AND i.state = 'updated' AS is_active,
+        AND i.state = 'updated' AS is_active,
         v.critical,
         v.high,
         v.medium,

--- a/internal/database/sql/workloads.sql.go
+++ b/internal/database/sql/workloads.sql.go
@@ -490,7 +490,7 @@ SET
 WHERE
     image_name = $2
     AND image_tag = $3
-    AND state NOT IN ('failed', 'unrecoverable', 'no_attestation')
+    AND state NOT IN ('failed', 'unrecoverable')
 `
 
 type UpdateWorkloadStateByImageParams struct {

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -957,7 +957,7 @@ func TestBatchUpdateWorkloadStateByImage_TerminalStatesNotOverwritten(t *testing
 		{"wl-updated", sql.WorkloadStateUpdated, true},
 		{"wl-failed", sql.WorkloadStateFailed, false},
 		{"wl-unrecoverable", sql.WorkloadStateUnrecoverable, false},
-		{"wl-no-attestation", sql.WorkloadStateNoAttestation, false},
+		{"wl-no-attestation", sql.WorkloadStateNoAttestation, true},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Problem

Workloads stuck in `no_attestation` state could never recover, even when the image was subsequently scanned successfully.

### Root cause

A race condition in `GetAttestationJob` (MaxAttempts: 4, 1-minute retries):
- Multiple workloads share the same image across clusters
- One cluster exhausts all retries before attestation becomes available → workload = `no_attestation`, image = `failed`
- Another cluster retries later and succeeds → image transitions to `updated`
- But `UpdateWorkloadStateByImage` had `AND state NOT IN ('failed', 'unrecoverable', 'no_attestation')`, permanently blocking the first cluster's workload from recovering

Confirmed in production: `nav-ident` in `prod` stuck in `no_attestation` while `dev` recovered correctly — same image tag, same time window.

## Fix

Remove `'no_attestation'` from the `NOT IN` guard in both `UpdateWorkloadStateByImage` and `BatchUpdateWorkloadStateByImage`.

`failed` and `unrecoverable` remain excluded — these are genuinely terminal states. `no_attestation` means "attestation not found at time of check", not "will never have attestation".

`MarkForResync` intentionally still excludes `ImageStateFailed` — images with no attestation (e.g. pensjon-pen) should not be infinitely retried. This fix only helps workloads whose image eventually transitions to `updated`.

## Changes

- `internal/database/queries/workloads.sql` — removed `'no_attestation'` from `NOT IN` guard
- `internal/database/sql/workloads.sql.go` — regenerated via sqlc
- `internal/database/sql/batch.go` — regenerated via sqlc  
- `internal/database/database_test.go` — added `TestUpdateWorkloadStateByImage_RecoverNoAttestation`

## Post-deploy

Run this one-time SQL to recover the ~39 existing stuck workloads whose image already has vuln data:

```sql
UPDATE workloads SET state = 'initialized', updated_at = NOW()
WHERE state = 'no_attestation'
  AND EXISTS (
    SELECT 1 FROM images
    WHERE name = workloads.image_name
      AND tag = workloads.image_tag
      AND state = 'updated'
  );
```

The remaining ~741 workloads with `image_state = failed` are legitimately no-attestation and are intentionally left as-is.