### PR TITLE
fix: skip GetAttestationJob when image is already processed

### DIFF
--- a/internal/manager/add_workload.go
+++ b/internal/manager/add_workload.go
@@ -93,17 +93,6 @@ func (a *AddWorkloadWorker) Work(ctx context.Context, job *river.Job[AddWorkload
 		return nil
 	}
 
-	if image.State == sql.ImageStateFailed {
-		if err := a.db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
-			State: sql.WorkloadStateNoAttestation,
-			ID:    id,
-		}); err != nil {
-			return fmt.Errorf("failed to set workload state %s: %w", sql.WorkloadStateNoAttestation, err)
-		}
-		recordStatusOutput(ctx, JobStatusNoAttestation)
-		return nil
-	}
-
 	err = a.jobClient.AddJob(ctx, &GetAttestationJob{
 		ImageName:    workload.ImageName,
 		ImageTag:     workload.ImageTag,

--- a/internal/manager/add_workload.go
+++ b/internal/manager/add_workload.go
@@ -70,6 +70,40 @@ func (a *AddWorkloadWorker) Work(ctx context.Context, job *river.Job[AddWorkload
 		return nil
 	}
 
+	image, err := a.db.GetImage(ctx, sql.GetImageParams{
+		Name: workload.ImageName,
+		Tag:  workload.ImageTag,
+	})
+	if err != nil {
+		a.log.WithError(err).WithFields(logrus.Fields{
+			"image": workload.ImageName,
+			"tag":   workload.ImageTag,
+		}).Warn("failed to get image state; proceeding to enqueue GetAttestationJob")
+		image = &sql.Image{}
+	}
+
+	if image.State == sql.ImageStateUpdated {
+		if err := a.db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+			State: sql.WorkloadStateUpdated,
+			ID:    id,
+		}); err != nil {
+			return fmt.Errorf("failed to set workload state %s: %w", sql.WorkloadStateUpdated, err)
+		}
+		recordStatusOutput(ctx, JobStatusUpdated)
+		return nil
+	}
+
+	if image.State == sql.ImageStateFailed {
+		if err := a.db.UpdateWorkloadState(ctx, sql.UpdateWorkloadStateParams{
+			State: sql.WorkloadStateNoAttestation,
+			ID:    id,
+		}); err != nil {
+			return fmt.Errorf("failed to set workload state %s: %w", sql.WorkloadStateNoAttestation, err)
+		}
+		recordStatusOutput(ctx, JobStatusNoAttestation)
+		return nil
+	}
+
 	err = a.jobClient.AddJob(ctx, &GetAttestationJob{
 		ImageName:    workload.ImageName,
 		ImageTag:     workload.ImageTag,

--- a/internal/manager/add_workload_test.go
+++ b/internal/manager/add_workload_test.go
@@ -1,0 +1,133 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/riverqueue/river"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nais/v13s/internal/database/sql"
+	sqmock "github.com/nais/v13s/internal/mocks/Querier"
+	"github.com/nais/v13s/internal/model"
+)
+
+type trackingJobClient struct {
+	addedJobs []river.JobArgs
+}
+
+func (t *trackingJobClient) AddJob(_ context.Context, args river.JobArgs) error {
+	t.addedJobs = append(t.addedJobs, args)
+	return nil
+}
+
+func (t *trackingJobClient) GetWorkers() *river.Workers    { return nil }
+func (t *trackingJobClient) Start(_ context.Context) error { return nil }
+func (t *trackingJobClient) Stop(_ context.Context) error  { return nil }
+
+var workloadID = pgtype.UUID{Bytes: [16]byte{1}, Valid: true}
+
+func makeAddWorkloadJob(imageName, imageTag string) *river.Job[AddWorkloadJob] {
+	return &river.Job[AddWorkloadJob]{
+		Args: AddWorkloadJob{
+			Workload: &model.Workload{
+				Name:      "test-workload",
+				Cluster:   "dev",
+				Namespace: "test-ns",
+				Type:      model.WorkloadTypeApp,
+				ImageName: imageName,
+				ImageTag:  imageTag,
+			},
+		},
+	}
+}
+
+func TestAddWorkloadWorker_SkipsGetAttestationWhenImageUpdated(t *testing.T) {
+	db := sqmock.NewMockQuerier(t)
+	jc := &trackingJobClient{}
+
+	db.EXPECT().CreateImage(mock.Anything, mock.Anything).Return(nil)
+	db.EXPECT().InitializeWorkload(mock.Anything, mock.Anything).Return(workloadID, nil)
+	db.EXPECT().GetImage(mock.Anything, mock.Anything).Return(&sql.Image{
+		Name:  "myimage",
+		Tag:   "v1",
+		State: sql.ImageStateUpdated,
+	}, nil)
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
+		return p.State == sql.WorkloadStateUpdated && p.ID == workloadID
+	})).Return(nil)
+
+	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
+	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
+
+	require.NoError(t, err)
+	require.Empty(t, jc.addedJobs, "GetAttestationJob should not be enqueued when image is already updated")
+}
+
+func TestAddWorkloadWorker_SkipsGetAttestationWhenImageFailed(t *testing.T) {
+	db := sqmock.NewMockQuerier(t)
+	jc := &trackingJobClient{}
+
+	db.EXPECT().CreateImage(mock.Anything, mock.Anything).Return(nil)
+	db.EXPECT().InitializeWorkload(mock.Anything, mock.Anything).Return(workloadID, nil)
+	db.EXPECT().GetImage(mock.Anything, mock.Anything).Return(&sql.Image{
+		Name:  "myimage",
+		Tag:   "v1",
+		State: sql.ImageStateFailed,
+	}, nil)
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
+		return p.State == sql.WorkloadStateNoAttestation && p.ID == workloadID
+	})).Return(nil)
+
+	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
+	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
+
+	require.NoError(t, err)
+	require.Empty(t, jc.addedJobs, "GetAttestationJob should not be enqueued when image is already failed")
+}
+
+func TestAddWorkloadWorker_EnqueuesGetAttestationWhenImageInitialized(t *testing.T) {
+	db := sqmock.NewMockQuerier(t)
+	jc := &trackingJobClient{}
+
+	db.EXPECT().CreateImage(mock.Anything, mock.Anything).Return(nil)
+	db.EXPECT().InitializeWorkload(mock.Anything, mock.Anything).Return(workloadID, nil)
+	db.EXPECT().GetImage(mock.Anything, mock.Anything).Return(&sql.Image{
+		Name:  "myimage",
+		Tag:   "v1",
+		State: sql.ImageStateInitialized,
+	}, nil)
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
+		return p.State == sql.WorkloadStateUpdated && p.ID == workloadID
+	})).Return(nil)
+
+	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
+	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
+
+	require.NoError(t, err)
+	require.Len(t, jc.addedJobs, 1, "GetAttestationJob should be enqueued when image is not yet processed")
+	_, ok := jc.addedJobs[0].(*GetAttestationJob)
+	require.True(t, ok, "enqueued job should be a GetAttestationJob")
+}
+
+func TestAddWorkloadWorker_FallsBackToGetAttestationOnGetImageError(t *testing.T) {
+	db := sqmock.NewMockQuerier(t)
+	jc := &trackingJobClient{}
+
+	db.EXPECT().CreateImage(mock.Anything, mock.Anything).Return(nil)
+	db.EXPECT().InitializeWorkload(mock.Anything, mock.Anything).Return(workloadID, nil)
+	db.EXPECT().GetImage(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("db error"))
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
+		return p.State == sql.WorkloadStateUpdated && p.ID == workloadID
+	})).Return(nil)
+
+	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
+	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
+
+	require.NoError(t, err)
+	require.Len(t, jc.addedJobs, 1, "GetAttestationJob should be enqueued when GetImage fails")
+}

--- a/internal/manager/add_workload_test.go
+++ b/internal/manager/add_workload_test.go
@@ -68,7 +68,7 @@ func TestAddWorkloadWorker_SkipsGetAttestationWhenImageUpdated(t *testing.T) {
 	require.Empty(t, jc.addedJobs, "GetAttestationJob should not be enqueued when image is already updated")
 }
 
-func TestAddWorkloadWorker_SkipsGetAttestationWhenImageFailed(t *testing.T) {
+func TestAddWorkloadWorker_EnqueuesGetAttestationWhenImageFailed(t *testing.T) {
 	db := sqmock.NewMockQuerier(t)
 	jc := &trackingJobClient{}
 
@@ -79,15 +79,13 @@ func TestAddWorkloadWorker_SkipsGetAttestationWhenImageFailed(t *testing.T) {
 		Tag:   "v1",
 		State: sql.ImageStateFailed,
 	}, nil)
-	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
-		return p.State == sql.WorkloadStateNoAttestation && p.ID == workloadID
-	})).Return(nil)
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.Anything).Return(nil)
 
 	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
 	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
 
 	require.NoError(t, err)
-	require.Empty(t, jc.addedJobs, "GetAttestationJob should not be enqueued when image is already failed")
+	require.Len(t, jc.addedJobs, 1, "GetAttestationJob should be enqueued when image is failed — it sets the correct terminal state")
 }
 
 func TestAddWorkloadWorker_EnqueuesGetAttestationWhenImageInitialized(t *testing.T) {

--- a/internal/manager/add_workload_test.go
+++ b/internal/manager/add_workload_test.go
@@ -79,13 +79,17 @@ func TestAddWorkloadWorker_EnqueuesGetAttestationWhenImageFailed(t *testing.T) {
 		Tag:   "v1",
 		State: sql.ImageStateFailed,
 	}, nil)
-	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.Anything).Return(nil)
+	db.EXPECT().UpdateWorkloadState(mock.Anything, mock.MatchedBy(func(p sql.UpdateWorkloadStateParams) bool {
+		return p.State == sql.WorkloadStateUpdated && p.ID == workloadID
+	})).Return(nil)
 
 	worker := &AddWorkloadWorker{db: db, jobClient: jc, log: logrus.NewEntry(logrus.New())}
 	err := worker.Work(context.Background(), makeAddWorkloadJob("myimage", "v1"))
 
 	require.NoError(t, err)
 	require.Len(t, jc.addedJobs, 1, "GetAttestationJob should be enqueued when image is failed — it sets the correct terminal state")
+	_, ok := jc.addedJobs[0].(*GetAttestationJob)
+	require.True(t, ok, "enqueued job should be a GetAttestationJob")
 }
 
 func TestAddWorkloadWorker_EnqueuesGetAttestationWhenImageInitialized(t *testing.T) {
@@ -128,4 +132,6 @@ func TestAddWorkloadWorker_FallsBackToGetAttestationOnGetImageError(t *testing.T
 
 	require.NoError(t, err)
 	require.Len(t, jc.addedJobs, 1, "GetAttestationJob should be enqueued when GetImage fails")
+	_, ok := jc.addedJobs[0].(*GetAttestationJob)
+	require.True(t, ok, "enqueued job should be a GetAttestationJob")
 }


### PR DESCRIPTION
## Problem

When a new workload is deployed for an image that is already fully processed (`updated`), `AddWorkloadWorker` would still enqueue `GetAttestationJob`. If that job exhausted all 4 retries before the attestation became available (timing window), the workload got permanently stuck in `no_attestation` with no future event to rescue it.

This was the second race condition causing `no_attestation` deadlocks (PR #340 fixed the first — the NOT IN guard that prevented recovery).

## Root cause

`AddWorkloadWorker` did not check whether the image had already been processed before enqueuing `GetAttestationJob`.

## Fix

After `CreateImage`, call `GetImage` to check the existing image state:

- **`ImageStateUpdated`** → set workload to `updated` immediately, skip `GetAttestationJob`
- **`ImageStateFailed`** → fall through and enqueue `GetAttestationJob` — it will fail fast and set the correct terminal state (`no_attestation` or `unrecoverable`) through the existing decision table. We cannot short-circuit here because `failed` can come from three distinct paths with different workload states.
- **Any other state / `GetImage` error** → enqueue `GetAttestationJob` as before (safe fallback)

## Testing

4 unit tests added in `add_workload_test.go`:
- Skip `GetAttestationJob` when image is already `updated`
- Enqueue `GetAttestationJob` when image is `failed` (let decision table handle terminal state)
- Enqueue `GetAttestationJob` when image is `initialized`
- Fall back to `GetAttestationJob` when `GetImage` returns an error

## Related

- Fixes workloads stuck in `no_attestation` when image was already `updated`
- Companion to #340 (removed `no_attestation` from NOT IN guard)
- ~21 production workloads currently stuck need one-time SQL recovery after deploy:
```sql
UPDATE workloads SET state = 'updated', updated_at = NOW()
WHERE state = 'no_attestation'
  AND EXISTS (
    SELECT 1 FROM images
    WHERE name = workloads.image_name
      AND tag = workloads.image_tag
      AND state = 'updated'
  );
```