### PR TITLE
Commit new updates to parser

### DIFF
--- a/internal/kubernetes/handler.go
+++ b/internal/kubernetes/handler.go
@@ -201,10 +201,19 @@ func jobName(job *nais.Naisjob) string {
 	return job.GetName()
 }
 
-func imageNameTag(image string) (string, string) {
-	if before, after, ok := strings.Cut(image, "@"); ok {
-		return before, after
+func imageNameTag(image string) (imageName, tagName string) {
+	if before, digest, ok := strings.Cut(image, "@"); ok {
+		name, tag := splitNameTag(before)
+
+		if tag != "" {
+			return name, tag + "@" + digest
+		}
+		return name, digest
 	}
+	return splitNameTag(image)
+}
+
+func splitNameTag(image string) (imageName, tagName string) {
 	i := strings.LastIndex(image, ":")
 	if i < 0 || i == len(image)-1 {
 		return image, ""

--- a/internal/kubernetes/handler_test.go
+++ b/internal/kubernetes/handler_test.go
@@ -1,0 +1,75 @@
+package kubernetes
+
+import "testing"
+
+func TestImageNameTag(t *testing.T) {
+	tests := []struct {
+		name          string
+		image         string
+		wantImageName string
+		wantTagName   string
+	}{
+		{
+			name:          "tag only",
+			image:         "my-app:v1.2.3",
+			wantImageName: "my-app",
+			wantTagName:   "v1.2.3",
+		},
+		{
+			name:          "digest only",
+			image:         "my-app@sha256:abcdef123456",
+			wantImageName: "my-app",
+			wantTagName:   "sha256:abcdef123456",
+		},
+		{
+			name:          "tag and digest",
+			image:         "my-app:v1.2.3@sha256:abcdef123456",
+			wantImageName: "my-app",
+			wantTagName:   "v1.2.3@sha256:abcdef123456",
+		},
+		{
+			name:          "nested repository with tag and digest",
+			image:         "acme/widgets/frobnicator:v42@sha256:deadbeefcafebabe",
+			wantImageName: "acme/widgets/frobnicator",
+			wantTagName:   "v42@sha256:deadbeefcafebabe",
+		},
+		{
+			name:          "nested repository with digest only",
+			image:         "acme/widgets/frobnicator@sha256:deadbeefcafebabe",
+			wantImageName: "acme/widgets/frobnicator",
+			wantTagName:   "sha256:deadbeefcafebabe",
+		},
+		{
+			name:          "registry with port and tag",
+			image:         "registry.example:5000/my-app:v1.2.3",
+			wantImageName: "registry.example:5000/my-app",
+			wantTagName:   "v1.2.3",
+		},
+		{
+			name:          "registry with port tag and digest",
+			image:         "registry.example:5000/my-app:v1.2.3@sha256:abcdef123456",
+			wantImageName: "registry.example:5000/my-app",
+			wantTagName:   "v1.2.3@sha256:abcdef123456",
+		},
+		{
+			name:          "image without tag",
+			image:         "my-app",
+			wantImageName: "my-app",
+			wantTagName:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotImageName, gotTagName := imageNameTag(tt.image)
+
+			if gotImageName != tt.wantImageName {
+				t.Fatalf("imageName = %q, want %q", gotImageName, tt.wantImageName)
+			}
+
+			if gotTagName != tt.wantTagName {
+				t.Fatalf("tagName = %q, want %q", gotTagName, tt.wantTagName)
+			}
+		})
+	}
+}

--- a/internal/manager/get_attestation.go
+++ b/internal/manager/get_attestation.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -76,7 +77,7 @@ func (g *GetAttestationWorker) Work(ctx context.Context, job *river.Job[GetAttes
 	}
 
 	// 1. Call external verifier.
-	att, err := g.verifier.GetAttestation(ctx, fmt.Sprintf("%s:%s", imageName, imageTag))
+	att, err := g.verifier.GetAttestation(ctx, imageReference(imageName, imageTag))
 	g.workloadCounter.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("hasAttestation", fmt.Sprint(att != nil)),
 	))
@@ -116,7 +117,7 @@ func (g *GetAttestationWorker) Work(ctx context.Context, job *river.Job[GetAttes
 	if decision.ImageState != nil {
 		imageState := *decision.ImageState
 		if imageState == sql.ImageStateFailed && job.Attempt < job.MaxAttempts {
-			imageState = sql.ImageState("")
+			imageState = ""
 		}
 		if imageState != "" {
 			n, dbErr := g.db.UpdateImageState(dbCtx, sql.UpdateImageStateParams{
@@ -175,6 +176,30 @@ func (g *GetAttestationWorker) Work(ctx context.Context, job *river.Job[GetAttes
 
 	span.SetStatus(codes.Ok, "attestation processing complete")
 	return err // nil on success; non-nil recoverable error triggers River retry
+}
+
+// imageReference rebuilds an OCI image reference from a stored image name and tag value.
+//
+// Accepted imageTag formats:
+//   - "1.2.3" -> "<imageName>:1.2.3"
+//   - "<algo>:<hex>" (or "@<algo>:<hex>") -> "<imageName>@<algo>:<hex>"
+//   - "1.2.3@<algo>:<hex>" -> "<imageName>:1.2.3@<algo>:<hex>"
+func imageReference(imageName, imageTag string) string {
+	if imageTag == "" {
+		return imageName
+	}
+
+	imageTag = strings.TrimPrefix(imageTag, "@")
+
+	if strings.Contains(imageTag, "@") {
+		return fmt.Sprintf("%s:%s", imageName, imageTag)
+	}
+
+	if strings.Contains(imageTag, ":") {
+		return fmt.Sprintf("%s@%s", imageName, imageTag)
+	}
+
+	return fmt.Sprintf("%s:%s", imageName, imageTag)
 }
 
 func describeGetAttestationDecision(d Decision) string {

--- a/internal/manager/get_attestation_worker_test.go
+++ b/internal/manager/get_attestation_worker_test.go
@@ -118,3 +118,61 @@ func TestGetAttestationWorker_AttestationFound_EnqueuesUpload(t *testing.T) {
 	err := worker.Work(ctx, job)
 	require.NoError(t, err)
 }
+
+func TestImageReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		tag      string
+		expected string
+	}{
+		{
+			name:     "regular tag",
+			image:    "example.com/team/app",
+			tag:      "1.2.3",
+			expected: "example.com/team/app:1.2.3",
+		},
+		{
+			name:     "digest tag",
+			image:    "example.com/team/app",
+			tag:      "sha256:abc",
+			expected: "example.com/team/app@sha256:abc",
+		},
+		{
+			name:     "digest tag with leading at",
+			image:    "example.com/team/app",
+			tag:      "@sha256:abc",
+			expected: "example.com/team/app@sha256:abc",
+		},
+		{
+			name:     "non sha256 digest tag",
+			image:    "example.com/team/app",
+			tag:      "sha512:abc",
+			expected: "example.com/team/app@sha512:abc",
+		},
+		{
+			name:     "non sha256 digest tag with leading at",
+			image:    "example.com/team/app",
+			tag:      "@sha512:abc",
+			expected: "example.com/team/app@sha512:abc",
+		},
+		{
+			name:     "tag and digest",
+			image:    "example.com/team/app",
+			tag:      "1.2.3@sha256:abc",
+			expected: "example.com/team/app:1.2.3@sha256:abc",
+		},
+		{
+			name:     "empty tag",
+			image:    "example.com/team/app",
+			tag:      "",
+			expected: "example.com/team/app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, imageReference(tt.image, tt.tag))
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves handling and parsing of OCI image references and tags, ensuring correct support for images specified with tags, digests, or both. It also adds comprehensive unit tests to validate this logic. The changes affect both the core parsing logic and its usage in attestation workflows.

**Image reference/tag parsing improvements:**

* Refactored the `imageNameTag` function in `handler.go` to correctly parse image references containing tags, digests, or both, and introduced a helper `splitNameTag` for clarity.
* Added a new `imageReference` function in `get_attestation.go` to reconstruct full image references from parsed image name and tag, handling all valid OCI formats.
* Updated the attestation worker to use the new `imageReference` function, ensuring correct image string formatting when calling external verifiers.

**Testing improvements:**

* Added unit tests for `imageNameTag` in a new `handler_test.go`, covering a wide range of image reference formats.
* Added unit tests for `imageReference` in `get_attestation_worker_test.go` to verify correct reconstruction of image references.

**Minor fixes:**

* Simplified image state assignment logic in the attestation worker by directly assigning an empty string instead of using a constant.
* Added a missing import for `strings` in `get_attestation.go`.